### PR TITLE
Fix textOnly crash on missing message content

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -58,8 +58,10 @@ function textAndPlaceholders(
 	return parts.join("\n");
 }
 
-function textOnly(content: string | Array<{ type?: string; text?: string }>): string {
+function textOnly(content: unknown): string {
+	if (content == null) return "";
 	if (typeof content === "string") return content;
+	if (!Array.isArray(content)) return "";
 	return content
 		.filter((b): b is TextContent => b?.type === "text" && typeof b.text === "string")
 		.map((b) => b.text)

--- a/tests/serialize.test.ts
+++ b/tests/serialize.test.ts
@@ -65,6 +65,19 @@ describe("source-addressable observer serialization", () => {
 			"[User @ 2026-05-02 10:00]: Please remember this decision.",
 		);
 	});
+
+	it("treats null, undefined, and non-array message content as empty text", () => {
+		const source = serializeSourceAddressedBranchEntries([
+			messageEntry({ id: "entry-null", message: { role: "user", timestamp: "2026-05-02 10:03", content: null } }),
+			messageEntry({ id: "entry-missing", message: { role: "user", timestamp: "2026-05-02 10:04" } }),
+			messageEntry({ id: "entry-object", message: { role: "toolResult", timestamp: "2026-05-02 10:05", toolName: "read", content: { unexpected: true } } }),
+		]);
+
+		expect(source.sourceEntryIds).toEqual(["entry-null", "entry-missing", "entry-object"]);
+		expect(source.text).toContain("[User @ 2026-05-02 10:03]: ");
+		expect(source.text).toContain("[User @ 2026-05-02 10:04]: ");
+		expect(source.text).toContain("[Tool result for read @ 2026-05-02 10:05]: ");
+	});
 });
 
 describe("recall source rendering", () => {


### PR DESCRIPTION
## Summary
- Guard observer serialization against null, missing, or non-array message content
- Preserve existing string/text-block serialization behavior
- Add regression coverage for null, missing, and object-shaped message content

## Validation
- npm test -- tests/serialize.test.ts
- npm run typecheck
- npm test
- npm pack --dry-run --json

Closes #6