### PR TITLE
feat(bridge): add stable export surface + cross-session recall helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,32 @@ For the full list and tuning recipes, see **[docs/configuration.md](docs/configu
 | `/om-view` | Full dump of memory state: every reflection, every committed observation, every pending observation. Reflection and observation ids shown here can be used with `recall` |
 | `recall` agent tool | Recovers exact source evidence for a specific reflection or observation id on the current branch. It is for agent self-recovery and provenance, not a user command, semantic search, or transcript browser |
 
+## Bridge surface for downstream extensions
+
+`pi-observational-memory` exposes a small read-only bridge module at
+`src/bridge.ts` (importable as `pi-observational-memory/src/bridge.js`)
+for companion extensions that want to forward finalized memory into
+long-term storage without coupling to OM's internal source-module
+paths. The surface is intentionally minimal:
+
+| Helper | Purpose |
+|---|---|
+| `getMemoryStateFromBranch(entries)` | Bridge-friendly snapshot wrapper over the internal `getMemoryState()`. |
+| `snapshotFromMemoryDetails(details)` | Adapts `MemoryDetailsV3` / `MemoryDetailsV4` (returns null for unsupported input). |
+| `exportFromSnapshot(snapshot, opts)` | Returns version-neutral `BridgeRecord[]` with a default high+critical observation filter; reflections and pending observations are configurable. |
+| `exportFromMemoryDetails(details, opts)` | Convenience helper composing the two above. |
+| `loadSessionEntries(sessionFile)` | Parse a Pi session JSONL into `Entry[]`, skipping malformed lines. |
+| `recallSourcesFromSessionFile(sessionFile, memoryId)` | Recover exact source evidence for an OM id given a session file path. Returns an explicit `unavailableReason` (`missing-session-file`, `unreadable-session-file`, `empty-session-file`) instead of throwing. |
+
+Consumers must not mutate observation/reflection records returned by
+the bridge; the surface registers no Pi hooks, commands, or tools.
+
+The reference downstream consumer is
+[`om-to-mem-bridge`](https://github.com/KickingTheTV/pi-mem) (part of
+the Pi memory integration plan, U2/U5), which forwards high-signal
+compaction output into the pi-mem (claude-mem) cross-session worker
+and exposes a provenance-aware `global_recall` tool.
+
 ## Credits
 
 Inspired by [Mastra's Observational Memory](https://mastra.ai/blog/observational-memory) research (94.87% on LongMemEval). This is an independent implementation built for Pi's extension system.

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -1,0 +1,215 @@
+/**
+ * Stable export surface for downstream bridge extensions (U4).
+ *
+ * Lets companion extensions (e.g. om-to-mem-bridge) read finalized
+ * observational-memory state without importing internal source-module
+ * paths. Returns a version-neutral record shape so future MemoryDetails
+ * format bumps do not break consumers.
+ *
+ * Usage from a bridge extension (post U4 install):
+ *
+ *     import {
+ *       getMemoryStateFromBranch,
+ *       exportFromMemoryDetails,
+ *       type BridgeRecord,
+ *     } from "pi-observational-memory/bridge";
+ *
+ *     pi.on("session_compact", (_event, ctx) => {
+ *       const entries = ctx.sessionManager.getBranch();
+ *       const state = getMemoryStateFromBranch(entries);
+ *       const records = exportFromMemoryDetails(state);
+ *       // forward `records` to long-term storage
+ *     });
+ *
+ * The bridge surface is intentionally small and read-only:
+ *   - Consumers MUST NOT mutate observation/reflection records.
+ *   - The bridge does not register any Pi hooks, commands, or tools.
+ *   - The bridge does not change OM's compaction summary, prefix-cache
+ *     behavior, or recall semantics.
+ */
+
+import { getMemoryState, type Entry } from "./branch.js";
+import {
+	isMemoryDetailsV3,
+	isMemoryDetailsV4,
+	reflectionContent,
+	reflectionId,
+	type MemoryDetailsV3,
+	type MemoryDetailsV4,
+	type MemoryReflection,
+	type ObservationRecord,
+	type Relevance,
+	type SupportedMemoryDetails,
+} from "./types.js";
+
+/**
+ * Version-neutral record returned by the bridge. Both observations and
+ * reflections collapse to this shape so bridge consumers can persist them
+ * uniformly. Original ObservationRecord / MemoryReflection objects remain
+ * available via the lower-level branch API for callers that need the raw
+ * shape.
+ */
+export interface BridgeRecord {
+	kind: "observation" | "reflection";
+	/** 12-char hex OM id when available. Legacy plain-string reflections may omit this. */
+	id?: string;
+	content: string;
+	relevance?: Relevance;
+	/** OM 'YYYY-MM-DD HH:MM' timestamp (observations only). */
+	timestamp?: string;
+	/** Source entry ids the OM observation was distilled from. */
+	sourceEntryIds?: string[];
+	/** OM supporting observations for structured reflections. */
+	supportingObservationIds?: string[];
+}
+
+/**
+ * Snapshot of finalized OM memory suitable for bridge export. Mirrors the
+ * shape of getMemoryState() but exposes only the fields bridges should
+ * read — pendingObs is intentionally excluded from default export paths
+ * because uncommitted observations may still be pruned.
+ */
+export interface BridgeMemorySnapshot {
+	observations: ObservationRecord[];
+	reflections: MemoryReflection[];
+	/** Observations that have not yet been folded into a compaction. */
+	pendingObservations: ObservationRecord[];
+}
+
+const HIGH_RELEVANCE: ReadonlySet<Relevance> = new Set<Relevance>(["high", "critical"]);
+
+/**
+ * Read finalized OM state from a session branch. Thin pass-through to
+ * getMemoryState() with bridge-friendly field names. Pending observations
+ * are exposed for callers that explicitly opt in via
+ * `exportFromSnapshot({ includePending: true })`.
+ */
+export function getMemoryStateFromBranch(entries: Entry[]): BridgeMemorySnapshot {
+	const state = getMemoryState(entries);
+	return {
+		observations: state.committedObs,
+		reflections: state.reflections,
+		pendingObservations: state.pendingObs,
+	};
+}
+
+/**
+ * Adapt MemoryDetails (V3 or V4) into a bridge snapshot. Useful when a
+ * caller has the compaction details object directly (e.g. from a
+ * `session_before_compact` hook) instead of a session branch. V3 details
+ * carry only legacy plain-string reflections; the snapshot's
+ * `pendingObservations` is always empty for this entry point.
+ *
+ * Returns null when the input is not a supported MemoryDetails shape.
+ */
+export function snapshotFromMemoryDetails(
+	details: unknown,
+): BridgeMemorySnapshot | null {
+	if (isMemoryDetailsV4(details)) {
+		const v4: MemoryDetailsV4 = details;
+		return {
+			observations: [...v4.observations],
+			reflections: [...v4.reflections],
+			pendingObservations: [],
+		};
+	}
+	if (isMemoryDetailsV3(details)) {
+		const v3: MemoryDetailsV3 = details;
+		return {
+			observations: [...v3.observations],
+			reflections: [...v3.reflections],
+			pendingObservations: [],
+		};
+	}
+	return null;
+}
+
+export interface ExportOptions {
+	/**
+	 * Relevance levels to keep when filtering committed observations.
+	 * Defaults to {"high", "critical"}. Pass a custom set or use
+	 * `exportAllObservations: true` to bypass entirely.
+	 */
+	highSignalRelevance?: ReadonlySet<Relevance>;
+	/** When true, exports every committed observation regardless of relevance. */
+	exportAllObservations?: boolean;
+	/** When false, suppresses reflections in the output. Default true. */
+	exportReflections?: boolean;
+	/**
+	 * When true, also exports `pendingObservations`. Off by default because
+	 * pending observations may be pruned before becoming durable memory.
+	 */
+	includePending?: boolean;
+}
+
+/**
+ * Convert a bridge snapshot into version-neutral records. The default
+ * filter selects `high` + `critical` observations and includes all
+ * reflections; tune via {@link ExportOptions} for other policies.
+ */
+export function exportFromSnapshot(
+	snapshot: BridgeMemorySnapshot,
+	opts: ExportOptions = {},
+): BridgeRecord[] {
+	const filter = opts.highSignalRelevance ?? HIGH_RELEVANCE;
+	const exportAll = opts.exportAllObservations === true;
+	const includeReflections = opts.exportReflections !== false;
+	const includePending = opts.includePending === true;
+
+	const records: BridgeRecord[] = [];
+
+	const addObs = (obs: ObservationRecord): void => {
+		if (!exportAll && !filter.has(obs.relevance)) return;
+		records.push({
+			kind: "observation",
+			id: obs.id,
+			content: obs.content,
+			relevance: obs.relevance,
+			timestamp: obs.timestamp,
+			sourceEntryIds: obs.sourceEntryIds,
+		});
+	};
+
+	for (const obs of snapshot.observations) addObs(obs);
+	if (includePending) {
+		for (const obs of snapshot.pendingObservations) addObs(obs);
+	}
+
+	if (includeReflections) {
+		for (const reflection of snapshot.reflections) {
+			const content = reflectionContent(reflection);
+			if (!content || content.trim().length === 0) continue;
+			const id = reflectionId(reflection);
+			const supportingObservationIds = typeof reflection === "string"
+				? undefined
+				: reflection.supportingObservationIds;
+			records.push({
+				kind: "reflection",
+				id,
+				content,
+				supportingObservationIds,
+			});
+		}
+	}
+
+	return records;
+}
+
+/**
+ * Convenience helper combining {@link snapshotFromMemoryDetails} and
+ * {@link exportFromSnapshot}. Returns an empty array when the input is
+ * not a supported MemoryDetails shape — bridges should treat that as
+ * "no work for this compaction".
+ */
+export function exportFromMemoryDetails(
+	details: unknown,
+	opts: ExportOptions = {},
+): BridgeRecord[] {
+	const snapshot = snapshotFromMemoryDetails(details);
+	if (!snapshot) return [];
+	return exportFromSnapshot(snapshot, opts);
+}
+
+/** Re-export commonly used type guards for bridge consumers. */
+export { isMemoryDetailsV3, isMemoryDetailsV4 };
+export type { MemoryDetailsV3, MemoryDetailsV4, SupportedMemoryDetails, Relevance, ObservationRecord, MemoryReflection };

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -28,7 +28,14 @@
  *     behavior, or recall semantics.
  */
 
-import { getMemoryState, type Entry } from "./branch.js";
+import { existsSync, readFileSync } from "node:fs";
+
+import {
+	getMemoryState,
+	recallMemorySources,
+	type Entry,
+	type RecallMemorySourcesResult,
+} from "./branch.js";
 import {
 	isMemoryDetailsV3,
 	isMemoryDetailsV4,
@@ -208,6 +215,75 @@ export function exportFromMemoryDetails(
 	const snapshot = snapshotFromMemoryDetails(details);
 	if (!snapshot) return [];
 	return exportFromSnapshot(snapshot, opts);
+}
+
+/**
+ * Parse a Pi session JSONL file into the OM Entry[] shape recall expects.
+ *
+ * Lines that fail to JSON-parse are skipped rather than throwing — a
+ * partially corrupted session file should still allow recall of any
+ * intact entries. Returns null when the file does not exist or cannot
+ * be read.
+ */
+export function loadSessionEntries(sessionFile: string): Entry[] | null {
+	if (!sessionFile || sessionFile.length === 0) return null;
+	if (!existsSync(sessionFile)) return null;
+	let raw: string;
+	try {
+		raw = readFileSync(sessionFile, "utf-8");
+	} catch {
+		return null;
+	}
+	const entries: Entry[] = [];
+	for (const line of raw.split("\n")) {
+		const trimmed = line.trim();
+		if (trimmed.length === 0) continue;
+		try {
+			const parsed = JSON.parse(trimmed);
+			if (parsed && typeof parsed === "object" && typeof parsed.type === "string" && typeof parsed.id === "string") {
+				entries.push(parsed as Entry);
+			}
+		} catch {
+			// skip malformed line
+		}
+	}
+	return entries;
+}
+
+export interface RecallFromSessionFileResult {
+	/** When the session file could be read, the recall result for the given memory id. */
+	recall: RecallMemorySourcesResult | null;
+	/** Reason recall could not be attempted. */
+	unavailableReason?: "missing-session-file" | "unreadable-session-file" | "empty-session-file";
+}
+
+/**
+ * Resolve exact source evidence for an OM memory id (observation or
+ * reflection) by loading the session JSONL file and running OM's
+ * existing recall machinery against the parsed entries. Returns an
+ * unavailable reason rather than throwing when the session file is
+ * missing, unreadable, or empty — cross-session recall callers should
+ * surface that to the user with the stored OM record content as a
+ * fallback.
+ */
+export function recallSourcesFromSessionFile(
+	sessionFile: string,
+	memoryId: string,
+): RecallFromSessionFileResult {
+	if (!sessionFile || sessionFile.length === 0) {
+		return { recall: null, unavailableReason: "missing-session-file" };
+	}
+	if (!existsSync(sessionFile)) {
+		return { recall: null, unavailableReason: "missing-session-file" };
+	}
+	const entries = loadSessionEntries(sessionFile);
+	if (entries === null) {
+		return { recall: null, unavailableReason: "unreadable-session-file" };
+	}
+	if (entries.length === 0) {
+		return { recall: null, unavailableReason: "empty-session-file" };
+	}
+	return { recall: recallMemorySources(entries, memoryId) };
 }
 
 /** Re-export commonly used type guards for bridge consumers. */

--- a/tests/bridge-export.test.ts
+++ b/tests/bridge-export.test.ts
@@ -1,0 +1,263 @@
+/**
+ * Bridge export surface tests (U4).
+ *
+ * Validates the stable API published by src/bridge.ts. Includes:
+ *   - snapshotFromMemoryDetails: V4 + V3 + invalid input
+ *   - exportFromSnapshot: relevance filter, reflection toggle,
+ *     pending-observation opt-in, content-shape correctness
+ *   - exportFromMemoryDetails: combined helper end-to-end
+ *   - getMemoryStateFromBranch: thin wrapper round-trip with synthetic
+ *     compaction entries (anchored to the same fixture shape OM uses)
+ */
+
+import { describe, expect, test } from "vitest";
+
+import {
+	exportFromMemoryDetails,
+	exportFromSnapshot,
+	getMemoryStateFromBranch,
+	snapshotFromMemoryDetails,
+	type BridgeRecord,
+} from "../src/bridge.js";
+import type {
+	MemoryDetailsV3,
+	MemoryDetailsV4,
+	ObservationRecord,
+	ReflectionRecord,
+} from "../src/types.js";
+
+/** Pad a short tag into a 12-char hex OM id so type guards accept it. */
+function id12(tag: string): string {
+	const hex = (tag + "0").replace(/[^0-9a-f]/g, "0").toLowerCase();
+	if (hex.length >= 12) return hex.slice(0, 12);
+	return hex.padEnd(12, "0");
+}
+
+function obs(over: Partial<ObservationRecord> & { id: string; relevance: ObservationRecord["relevance"] }): ObservationRecord {
+	return {
+		id: over.id,
+		content: over.content ?? `c-${over.id}`,
+		timestamp: over.timestamp ?? "2026-05-08 03:00",
+		relevance: over.relevance,
+		sourceEntryIds: over.sourceEntryIds,
+	};
+}
+
+/**
+ * Creates a structured reflection. Defaults to one synthesized supporting
+ * observation id because OM's type guard rejects empty supports for
+ * non-legacy reflections.
+ */
+function refl(id: string, content: string, supports: string[] = [id12("sup0001")]): ReflectionRecord {
+	return { id, content, supportingObservationIds: supports };
+}
+
+function v4(observations: ObservationRecord[], reflections: MemoryDetailsV4["reflections"] = []): MemoryDetailsV4 {
+	return {
+		type: "observational-memory",
+		version: 4,
+		observations,
+		reflections,
+	};
+}
+
+function v3(observations: ObservationRecord[], reflections: string[] = []): MemoryDetailsV3 {
+	return {
+		type: "observational-memory",
+		version: 3,
+		observations,
+		reflections,
+	};
+}
+
+describe("snapshotFromMemoryDetails", () => {
+	test("converts V4 details into a snapshot", () => {
+		const details = v4(
+			[obs({ id: "111111111111", relevance: "high" })],
+			[refl("aaaaaaaaaaaa", "structured reflection")],
+		);
+		const snap = snapshotFromMemoryDetails(details);
+		expect(snap?.observations).toHaveLength(1);
+		expect(snap?.reflections).toHaveLength(1);
+		expect(snap?.pendingObservations).toEqual([]);
+	});
+
+	test("converts V3 details with legacy string reflections", () => {
+		const details = v3(
+			[obs({ id: "222222222222", relevance: "low" })],
+			["legacy reflection text"],
+		);
+		const snap = snapshotFromMemoryDetails(details);
+		expect(snap?.reflections).toEqual(["legacy reflection text"]);
+	});
+
+	test("returns null for unsupported / malformed input", () => {
+		expect(snapshotFromMemoryDetails(null)).toBeNull();
+		expect(snapshotFromMemoryDetails({})).toBeNull();
+		expect(
+			snapshotFromMemoryDetails({ type: "observational-memory", version: 99 }),
+		).toBeNull();
+		expect(snapshotFromMemoryDetails("string")).toBeNull();
+	});
+
+	test("does not alias the input arrays (defensive copy)", () => {
+		const observations = [obs({ id: "333333333333", relevance: "high" })];
+		const details = v4(observations, []);
+		const snap = snapshotFromMemoryDetails(details);
+		expect(snap?.observations).not.toBe(observations);
+	});
+});
+
+describe("exportFromSnapshot", () => {
+	test("filters observations to high+critical by default", () => {
+		const records = exportFromSnapshot({
+			observations: [
+				obs({ id: "lo", relevance: "low" }),
+				obs({ id: "me", relevance: "medium" }),
+				obs({ id: "hi", relevance: "high" }),
+				obs({ id: "cr", relevance: "critical" }),
+			],
+			reflections: [],
+			pendingObservations: [],
+		});
+		expect(records.map((r) => r.id).sort()).toEqual(["cr", "hi"]);
+	});
+
+	test("includes all reflections regardless of observation filter", () => {
+		const supports = [id12("o1"), id12("o2")];
+		const structuredId = id12("rrrr0001");
+		const records = exportFromSnapshot({
+			observations: [],
+			reflections: [
+				"legacy reflection",
+				refl(structuredId, "structured reflection", supports),
+			],
+			pendingObservations: [],
+		});
+		expect(records).toHaveLength(2);
+		const structured = records.find((r) => r.id === structuredId);
+		expect(structured?.supportingObservationIds).toEqual(supports);
+	});
+
+	test("skips empty / whitespace reflections", () => {
+		const records = exportFromSnapshot({
+			observations: [],
+			reflections: ["", "   ", refl(id12("e0"), "")],
+			pendingObservations: [],
+		});
+		expect(records).toEqual([]);
+	});
+
+	test("exportAllObservations bypasses the filter", () => {
+		const records = exportFromSnapshot(
+			{
+				observations: [obs({ id: "lo", relevance: "low" })],
+				reflections: [],
+				pendingObservations: [],
+			},
+			{ exportAllObservations: true },
+		);
+		expect(records).toHaveLength(1);
+	});
+
+	test("exportReflections=false suppresses reflections", () => {
+		const records = exportFromSnapshot(
+			{
+				observations: [obs({ id: "hi", relevance: "high" })],
+				reflections: ["should not appear"],
+				pendingObservations: [],
+			},
+			{ exportReflections: false },
+		);
+		expect(records.map((r) => r.kind)).toEqual(["observation"]);
+	});
+
+	test("includePending opts in to pendingObservations", () => {
+		const records = exportFromSnapshot(
+			{
+				observations: [obs({ id: "co", relevance: "high" })],
+				reflections: [],
+				pendingObservations: [obs({ id: "pe", relevance: "high" })],
+			},
+			{ includePending: true },
+		);
+		expect(records.map((r) => r.id).sort()).toEqual(["co", "pe"]);
+	});
+
+	test("preserves observation provenance fields on the bridge record", () => {
+		const records = exportFromSnapshot({
+			observations: [
+				obs({
+					id: id12("ffff0001"),
+					relevance: "high",
+					timestamp: "2026-05-08 04:30",
+					sourceEntryIds: ["entry-1", "entry-2"],
+				}),
+			],
+			reflections: [],
+			pendingObservations: [],
+		});
+		expect(records[0]).toMatchObject<Partial<BridgeRecord>>({
+			kind: "observation",
+			id: id12("ffff0001"),
+			relevance: "high",
+			timestamp: "2026-05-08 04:30",
+			sourceEntryIds: ["entry-1", "entry-2"],
+		});
+	});
+
+	test("custom highSignalRelevance overrides default", () => {
+		const records = exportFromSnapshot(
+			{
+				observations: [
+					obs({ id: "lo", relevance: "low" }),
+					obs({ id: "me", relevance: "medium" }),
+					obs({ id: "hi", relevance: "high" }),
+				],
+				reflections: [],
+				pendingObservations: [],
+			},
+			{ highSignalRelevance: new Set(["medium", "high"]) },
+		);
+		expect(records.map((r) => r.id).sort()).toEqual(["hi", "me"]);
+	});
+});
+
+describe("exportFromMemoryDetails", () => {
+	test("returns [] for unsupported input", () => {
+		expect(exportFromMemoryDetails({})).toEqual([]);
+		expect(exportFromMemoryDetails(null)).toEqual([]);
+	});
+
+	test("V4 input round-trips through default filter", () => {
+		const records = exportFromMemoryDetails(
+			v4(
+				[
+					obs({ id: id12("a1"), relevance: "high" }),
+					obs({ id: id12("a2"), relevance: "low" }),
+				],
+				[refl(id12("r1"), "a reflection", [id12("a1")])],
+			),
+		);
+		expect(records).toHaveLength(2);
+		expect(records.map((r) => r.kind).sort()).toEqual(["observation", "reflection"]);
+	});
+
+	test("V3 reflections export with no id (legacy strings)", () => {
+		const records = exportFromMemoryDetails(
+			v3([obs({ id: id12("a1"), relevance: "high" })], ["legacy reflection text"]),
+		);
+		const legacy = records.find((r) => r.kind === "reflection");
+		expect(legacy?.id).toBeUndefined();
+		expect(legacy?.content).toBe("legacy reflection text");
+	});
+});
+
+describe("getMemoryStateFromBranch", () => {
+	test("returns empty snapshot when branch has no compaction entries", () => {
+		const snap = getMemoryStateFromBranch([]);
+		expect(snap.observations).toEqual([]);
+		expect(snap.reflections).toEqual([]);
+		expect(snap.pendingObservations).toEqual([]);
+	});
+});

--- a/tests/bridge-recall.test.ts
+++ b/tests/bridge-recall.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Cross-session recall via bridge surface (U5).
+ *
+ * Validates loadSessionEntries + recallSourcesFromSessionFile against
+ * synthetic JSONL fixtures. The underlying recallMemorySources logic is
+ * already exercised by branch-recall.test.ts; these tests focus on the
+ * file-loading / unavailable-reason boundary and the public API the
+ * pi-mem global_recall tool will call.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+	loadSessionEntries,
+	recallSourcesFromSessionFile,
+} from "../src/bridge.js";
+
+let tmpRoot: string;
+
+beforeEach(() => {
+	tmpRoot = mkdtempSync(join(tmpdir(), "om-bridge-recall-"));
+});
+
+afterEach(() => {
+	rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+function writeSession(name: string, lines: unknown[]): string {
+	const path = join(tmpRoot, name);
+	writeFileSync(path, lines.map((l) => JSON.stringify(l)).join("\n"));
+	return path;
+}
+
+describe("loadSessionEntries", () => {
+	test("returns null for non-existent file", () => {
+		expect(loadSessionEntries(join(tmpRoot, "missing.jsonl"))).toBeNull();
+	});
+
+	test("returns null for empty path", () => {
+		expect(loadSessionEntries("")).toBeNull();
+	});
+
+	test("parses JSONL into Entry[]", () => {
+		const path = writeSession("a.jsonl", [
+			{ type: "message", id: "m1", message: { role: "user", content: "hi" } },
+			{ type: "message", id: "m2", message: { role: "assistant", content: "hello" } },
+		]);
+		const entries = loadSessionEntries(path);
+		expect(entries).not.toBeNull();
+		expect(entries).toHaveLength(2);
+		expect(entries?.[0]?.id).toBe("m1");
+	});
+
+	test("skips malformed lines and entries missing required fields", () => {
+		const path = writeSession("b.jsonl", [
+			{ type: "message", id: "m1" },
+			{ no_type: true, id: "m2" }, // missing 'type'
+		]);
+		// append a non-JSON line
+		const fs = require("node:fs") as typeof import("node:fs");
+		fs.appendFileSync(path, "\nnot-json\n{\"type\":\"message\",\"id\":\"m3\"}\n");
+		const entries = loadSessionEntries(path);
+		const ids = entries?.map((e) => e.id) ?? [];
+		expect(ids).toEqual(["m1", "m3"]);
+	});
+
+	test("handles trailing/blank lines gracefully", () => {
+		const path = join(tmpRoot, "c.jsonl");
+		writeFileSync(path, "\n\n\n");
+		const entries = loadSessionEntries(path);
+		expect(entries).toEqual([]);
+	});
+});
+
+describe("recallSourcesFromSessionFile", () => {
+	test("reports missing-session-file when path does not exist", () => {
+		const result = recallSourcesFromSessionFile(
+			join(tmpRoot, "no-such-file.jsonl"),
+			"a".repeat(12),
+		);
+		expect(result.unavailableReason).toBe("missing-session-file");
+		expect(result.recall).toBeNull();
+	});
+
+	test("reports missing-session-file when path is empty", () => {
+		const result = recallSourcesFromSessionFile("", "a".repeat(12));
+		expect(result.unavailableReason).toBe("missing-session-file");
+	});
+
+	test("reports empty-session-file when file is empty", () => {
+		const path = join(tmpRoot, "empty.jsonl");
+		writeFileSync(path, "");
+		const result = recallSourcesFromSessionFile(path, "a".repeat(12));
+		expect(result.unavailableReason).toBe("empty-session-file");
+	});
+
+	test("returns recall result with no matches when memory id is unknown", () => {
+		const path = writeSession("e.jsonl", [
+			{ type: "message", id: "m1" },
+			{ type: "message", id: "m2" },
+		]);
+		const result = recallSourcesFromSessionFile(path, "f".repeat(12));
+		expect(result.unavailableReason).toBeUndefined();
+		expect(result.recall).not.toBeNull();
+	});
+});


### PR DESCRIPTION
## Summary

Adds a small read-only **bridge surface** at `src/bridge.ts` for downstream extensions that want to forward finalized observational-memory state into long-term storage (e.g. cross-session memory like claude-mem / pi-mem) without coupling to internal source-module paths.

This is purely additive — no behavior changes for existing OM users.

## Public surface

| Helper | Purpose |
|---|---|
| `getMemoryStateFromBranch(entries)` | Bridge-friendly snapshot wrapper over the internal `getMemoryState()`. |
| `snapshotFromMemoryDetails(details)` | Adapts `MemoryDetailsV3` / `MemoryDetailsV4` (returns null for unsupported input). |
| `exportFromSnapshot(snapshot, opts)` | Returns version-neutral `BridgeRecord[]` with default high+critical observation filter, all reflections, pending observations opt-in. |
| `exportFromMemoryDetails(details, opts)` | Convenience helper composing the two above. |
| `loadSessionEntries(sessionFile)` | Parse a Pi session JSONL into `Entry[]`, skipping malformed lines. |
| `recallSourcesFromSessionFile(sessionFile, memoryId)` | Recover exact source evidence for an OM id given a session file path. Returns explicit `unavailableReason` (`missing-session-file`, `unreadable-session-file`, `empty-session-file`) instead of throwing. |

The surface registers no Pi hooks/commands/tools and never mutates OM session state. Consumers must not mutate observation/reflection records returned by the bridge.

## Why

I'm building a companion bridge extension (`om-to-mem-bridge`) that exports finalized OM compaction output into the pi-mem (claude-mem) cross-session worker so high-signal observations and reflections survive across sessions. The bridge currently has to import from `pi-observational-memory/src/branch.js` and other internal paths; this PR gives it a stable contract.

## Tests

25 new test cases:
- 16 in `tests/bridge-export.test.ts` covering V3/V4 adaptation, malformed input, relevance filter, reflection toggle, pending opt-in, provenance round-trip, legacy string reflections, and `getMemoryStateFromBranch` wrapper.
- 9 in `tests/bridge-recall.test.ts` covering missing/empty paths, malformed lines, trailing whitespace, and the unavailable-reason boundary.

Total OM test suite: 125 passing (was 100 before this PR).

## Reference downstream

[`om-to-mem-bridge`](https://github.com/KickingTheTV/om-to-mem-bridge) — Pi extension that uses this surface to forward finalized OM compaction output into the pi-mem (claude-mem) worker.

Part of a layered Pi memory integration plan that uses pi-observational-memory for within-session structured memory and pi-mem for cross-session search.