### PR TITLE
Fix llama.cpp timestamp grammar pattern

### DIFF
--- a/src/observer.ts
+++ b/src/observer.ts
@@ -25,11 +25,13 @@ const RelevanceSchema = Type.Union([
 	Type.Literal("critical"),
 ]);
 
+export const OBSERVATION_TIMESTAMP_PATTERN = "^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}$";
+
 const RecordObservationsSchema = Type.Object({
 	observations: Type.Array(
 		Type.Object({
 			timestamp: Type.String({
-				pattern: "^\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}$",
+				pattern: OBSERVATION_TIMESTAMP_PATTERN,
 				description: "Observation time in local 'YYYY-MM-DD HH:MM' format.",
 			}),
 			content: Type.String({

--- a/tests/observer.test.ts
+++ b/tests/observer.test.ts
@@ -1,6 +1,18 @@
 import { describe, expect, it } from "vitest";
 
-import { normalizeSourceEntryIds } from "../src/observer.js";
+import { normalizeSourceEntryIds, OBSERVATION_TIMESTAMP_PATTERN } from "../src/observer.js";
+
+describe("OBSERVATION_TIMESTAMP_PATTERN", () => {
+	it("matches local minute timestamps without regex shorthand escapes", () => {
+		expect(OBSERVATION_TIMESTAMP_PATTERN).not.toContain("\\d");
+
+		const pattern = new RegExp(OBSERVATION_TIMESTAMP_PATTERN);
+		expect(pattern.test("2026-05-02 10:30")).toBe(true);
+		expect(pattern.test("2026-5-02 10:30")).toBe(false);
+		expect(pattern.test("2026-05-02T10:30")).toBe(false);
+		expect(pattern.test("2026-05-02 10:30:00")).toBe(false);
+	});
+});
 
 describe("normalizeSourceEntryIds", () => {
 	const allowed = ["entry-a", "entry-b", "entry-c"];


### PR DESCRIPTION
## Summary
- Replace the observer timestamp schema's regex shorthand with explicit digit classes for llama.cpp GBNF compatibility
- Export the timestamp pattern for regression coverage
- Add tests proving the pattern accepts local minute timestamps, rejects malformed timestamps, and avoids \d

## Validation
- npm test -- tests/observer.test.ts
- npm run typecheck
- npm test
- git diff --check
- npm pack --dry-run --json

Closes #11