### PR TITLE
Copy om-view output to clipboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ For the full list and tuning recipes, see **[docs/configuration.md](docs/configu
 | Surface | What it does |
 |---|---|
 | `/om-status` | Memory totals, percent-to-threshold for each gate, passive-mode status, and in-flight flags for observer and compaction |
-| `/om-view` | Full dump of memory state: every reflection, every committed observation, every pending observation. Reflection and observation ids shown here can be used with `recall` |
+| `/om-view` | Full dump of memory state copied to the clipboard and printed: every reflection, every committed observation, every pending observation. Reflection and observation ids shown here can be used with `recall` |
 | `recall` agent tool | Recovers exact source evidence for a specific reflection or observation id on the current branch. It is for agent self-recovery and provenance, not a user command, semantic search, or transcript browser |
 
 ## Credits

--- a/src/clipboard.ts
+++ b/src/clipboard.ts
@@ -1,0 +1,63 @@
+import { spawn } from "node:child_process";
+
+export interface ClipboardCommand {
+	command: string;
+	args: string[];
+}
+
+export type ClipboardCommandRunner = (command: ClipboardCommand, text: string) => Promise<boolean>;
+
+export function getClipboardCommands(platform: NodeJS.Platform = process.platform): ClipboardCommand[] {
+	switch (platform) {
+		case "darwin":
+			return [{ command: "pbcopy", args: [] }];
+		case "win32":
+			return [{ command: "clip", args: [] }];
+		default:
+			return [
+				{ command: "wl-copy", args: [] },
+				{ command: "xclip", args: ["-selection", "clipboard"] },
+				{ command: "xsel", args: ["--clipboard", "--input"] },
+				{ command: "termux-clipboard-set", args: [] },
+			];
+	}
+}
+
+export async function copyTextToClipboard(
+	text: string,
+	runner: ClipboardCommandRunner = runClipboardCommand,
+	commands: ClipboardCommand[] = getClipboardCommands(),
+): Promise<boolean> {
+	for (const command of commands) {
+		if (await runner(command, text)) return true;
+	}
+	return false;
+}
+
+export function runClipboardCommand(command: ClipboardCommand, text: string): Promise<boolean> {
+	return new Promise((resolve) => {
+		let settled = false;
+		let timeout: ReturnType<typeof setTimeout> | undefined;
+
+		const finish = (ok: boolean) => {
+			if (settled) return;
+			settled = true;
+			if (timeout) clearTimeout(timeout);
+			resolve(ok);
+		};
+
+		const child = spawn(command.command, command.args, {
+			stdio: ["pipe", "ignore", "ignore"],
+		});
+
+		timeout = setTimeout(() => {
+			child.kill();
+			finish(false);
+		}, 2_000);
+
+		child.on("error", () => finish(false));
+		child.on("close", (code) => finish(code === 0));
+		child.stdin.on("error", () => undefined);
+		child.stdin.end(text, "utf8");
+	});
+}

--- a/src/commands/view.ts
+++ b/src/commands/view.ts
@@ -1,14 +1,20 @@
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { getMemoryState } from "../branch.js";
+import { copyTextToClipboard } from "../clipboard.js";
 import { observationPoolTokens as estimateObservationPoolTokens } from "../compaction.js";
 import { countByRelevance, formatRelevanceHistogram } from "../relevance.js";
 import type { Runtime } from "../runtime.js";
 import { estimateStringTokens } from "../tokens.js";
 import { reflectionContent, reflectionToPromptLine, type MemoryReflection, type ObservationRecord } from "../types.js";
 
-export function registerViewCommand(pi: ExtensionAPI, runtime: Runtime): void {
+interface ViewCommandOptions {
+	copyToClipboard?: (text: string) => Promise<boolean>;
+}
+
+export function registerViewCommand(pi: ExtensionAPI, runtime: Runtime, options: ViewCommandOptions = {}): void {
+	const copyToClipboard = options.copyToClipboard ?? copyTextToClipboard;
 	pi.registerCommand("om-view", {
-		description: "Print observational memory details (reflections + observations)",
+		description: "Print and copy observational memory details (reflections + observations)",
 		handler: async (_args, ctx) => {
 			runtime.ensureConfig(ctx.cwd);
 			const entries = ctx.sessionManager.getBranch() as Parameters<typeof getMemoryState>[0];
@@ -76,7 +82,14 @@ export function registerViewCommand(pi: ExtensionAPI, runtime: Runtime): void {
 			sections.push("");
 			sections.push("Tip: use /tree to browse the raw messages still live in the session.");
 
-			ctx.ui.notify(sections.join("\n"), "info");
+			const output = sections.join("\n");
+			const copied = await copyToClipboard(output);
+			ctx.ui.notify(
+				copied
+					? `${output}\n\nCopied /om-view output to clipboard.`
+					: `${output}\n\nWarning: failed to copy /om-view output to clipboard.`,
+				"info",
+			);
 		},
 	});
 }

--- a/tests/clipboard.test.ts
+++ b/tests/clipboard.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { copyTextToClipboard, getClipboardCommands, type ClipboardCommand } from "../src/clipboard.js";
+
+describe("clipboard", () => {
+	it("uses pbcopy on macOS", () => {
+		expect(getClipboardCommands("darwin")).toEqual([{ command: "pbcopy", args: [] }]);
+	});
+
+	it("tries common Linux clipboard commands", () => {
+		expect(getClipboardCommands("linux").map((command) => command.command)).toEqual([
+			"wl-copy",
+			"xclip",
+			"xsel",
+			"termux-clipboard-set",
+		]);
+	});
+
+	it("stops after the first successful clipboard command", async () => {
+		const commands: ClipboardCommand[] = [
+			{ command: "first", args: [] },
+			{ command: "second", args: [] },
+			{ command: "third", args: [] },
+		];
+		const runner = vi.fn(async (command: ClipboardCommand) => command.command === "second");
+
+		await expect(copyTextToClipboard("text", runner, commands)).resolves.toBe(true);
+		expect(runner.mock.calls.map(([command]) => command.command)).toEqual(["first", "second"]);
+	});
+
+	it("returns false when all clipboard commands fail", async () => {
+		const commands: ClipboardCommand[] = [
+			{ command: "first", args: [] },
+			{ command: "second", args: [] },
+		];
+		const runner = vi.fn(async () => false);
+
+		await expect(copyTextToClipboard("text", runner, commands)).resolves.toBe(false);
+		expect(runner).toHaveBeenCalledTimes(2);
+	});
+});

--- a/tests/view-command.test.ts
+++ b/tests/view-command.test.ts
@@ -45,7 +45,7 @@ function memoryDetailsV4(reflections: MemoryDetailsV4["reflections"] = [legacyRe
 	};
 }
 
-async function runView(details: MemoryDetailsV3 | MemoryDetailsV4): Promise<string> {
+async function runView(details: MemoryDetailsV3 | MemoryDetailsV4, clipboardResult = true): Promise<{ output: string; clipboardText: string }> {
 	let handler: ((args: string[], ctx: unknown) => Promise<void>) | undefined;
 	const pi = {
 		registerCommand: vi.fn((name: string, command: { handler: typeof handler }) => {
@@ -54,7 +54,8 @@ async function runView(details: MemoryDetailsV3 | MemoryDetailsV4): Promise<stri
 		}),
 	};
 	const runtime = { ensureConfig: vi.fn() };
-	registerViewCommand(pi as never, runtime as never);
+	const copyToClipboard = vi.fn(async () => clipboardResult);
+	registerViewCommand(pi as never, runtime as never, { copyToClipboard });
 	if (!handler) throw new Error("om-view handler was not registered");
 
 	const notify = vi.fn();
@@ -71,12 +72,13 @@ async function runView(details: MemoryDetailsV3 | MemoryDetailsV4): Promise<stri
 
 	const [[message, level]] = notify.mock.calls;
 	expect(level).toBe("info");
-	return message;
+	expect(copyToClipboard).toHaveBeenCalledTimes(1);
+	return { output: message, clipboardText: copyToClipboard.mock.calls[0][0] };
 }
 
 describe("/om-view", () => {
 	it("renders v4 reflection ids and legacy strings without extra labels", async () => {
-		const output = await runView(memoryDetailsV4());
+		const { output } = await runView(memoryDetailsV4());
 
 		expect(output).toContain(`[${reflectionRecord.id}] ${reflectionRecord.content}`);
 		expect(output).toContain(`[${migratedLegacyReflectionRecord.id}] ${migratedLegacyReflectionRecord.content}`);
@@ -91,7 +93,7 @@ describe("/om-view", () => {
 	});
 
 	it("counts observation tokens from rendered observation lines", async () => {
-		const output = await runView(memoryDetailsV4());
+		const { output } = await runView(memoryDetailsV4());
 		const renderedObsTokens = observationPoolTokens([committedObservation]);
 
 		expect(output).toContain(`1 observation (1 committed, 0 pending) · ~`);
@@ -99,10 +101,25 @@ describe("/om-view", () => {
 	});
 
 	it("keeps v3 legacy reflections plain", async () => {
-		const output = await runView(memoryDetailsV3());
+		const { output } = await runView(memoryDetailsV3());
 
 		expect(output).toContain(legacyReflection);
 		expect(output).not.toContain(`[${reflectionRecord.id}]`);
 		expect(output).not.toContain("[object Object]");
+	});
+
+	it("copies the rendered memory view to the clipboard", async () => {
+		const { output, clipboardText } = await runView(memoryDetailsV4());
+
+		expect(clipboardText).toContain(`[${committedObservation.id}] ${committedObservation.timestamp} [${committedObservation.relevance}] ${committedObservation.content}`);
+		expect(clipboardText).not.toContain("Copied /om-view output to clipboard.");
+		expect(output).toBe(`${clipboardText}\n\nCopied /om-view output to clipboard.`);
+	});
+
+	it("keeps showing the memory view when clipboard copy fails", async () => {
+		const { output, clipboardText } = await runView(memoryDetailsV4(), false);
+
+		expect(output).toBe(`${clipboardText}\n\nWarning: failed to copy /om-view output to clipboard.`);
+		expect(clipboardText).not.toContain("failed to copy");
 	});
 });


### PR DESCRIPTION
## Summary
- copy rendered /om-view output to the system clipboard while still printing it
- add a small cross-platform clipboard helper with macOS, Windows, Wayland, X11, and Termux fallbacks
- cover clipboard success/failure paths in tests and document the command behavior

## Tests
- npm run typecheck
- npm test