### PR TITLE
Fix passive-mode compaction re-observing entire raw tail on every cycle

### DIFF
--- a/src/branch.ts
+++ b/src/branch.ts
@@ -181,7 +181,15 @@ function rawTokensFromIndex(entries: Entry[], startIndex: number): number {
 }
 
 export function rawTokensSinceLastBound(entries: Entry[]): number {
-	return rawTokensFromIndex(entries, lastObservationCoverEndIdx(entries) + 1);
+	let startIdx = lastObservationCoverEndIdx(entries);
+	// Clamp to at least the last compaction entry — observation entries from before
+	// the last compaction may have coversUpToId pointing to deleted entries, causing
+	// lastObservationCoverEndIdx to return -1 and including the entire branch.
+	const lastCompactionIdx = findLastCompactionIndex(entries);
+	if (startIdx < lastCompactionIdx) {
+		startIdx = lastCompactionIdx;
+	}
+	return rawTokensFromIndex(entries, startIdx + 1);
 }
 
 export function rawTokensSinceLastCompaction(entries: Entry[]): number {

--- a/src/branch.ts
+++ b/src/branch.ts
@@ -208,7 +208,17 @@ export function firstRawIdAfter(entries: Entry[], afterIndex: number): string | 
 }
 
 export function gapRawEntries(entries: Entry[], newFirstKeptEntryId: string): Entry[] {
-	const lastBoundIdx = lastObservationCoverEndIdx(entries);
+	let lastBoundIdx = lastObservationCoverEndIdx(entries);
+	// Clamp the start boundary to at least the last compaction entry.
+	// Observation entries from before the last compaction may have coversUpToId values
+	// pointing to entries that were compacted away, or to entries before the compaction
+	// boundary whose content is already represented in the compaction details.
+	// Including them in the gap would cause the sync catch-up observer to re-process
+	// already-compact content and potentially produce a gap too large for a single LLM call.
+	const lastCompactionIdx = findLastCompactionIndex(entries);
+	if (lastBoundIdx < lastCompactionIdx) {
+		lastBoundIdx = lastCompactionIdx;
+	}
 	const newKeptIdx = entries.findIndex((e) => e.id === newFirstKeptEntryId);
 	if (newKeptIdx === -1) return [];
 	const result: Entry[] = [];

--- a/src/hooks/compaction-hook.ts
+++ b/src/hooks/compaction-hook.ts
@@ -5,8 +5,11 @@ import { resolveTurnLimits } from "../config.js";
 import {
 	collectObservationsByCoverage,
 	findLastCompactionIndex,
+	firstRawIdAfter,
 	gapRawEntries,
 	getMemoryState,
+	lastObservationCoverEndIdx,
+	rawTailEntriesBetween,
 } from "../branch.js";
 import {
 	REFLECTOR_MAX_PASSES,
@@ -24,7 +27,7 @@ import { observationsToPromptLines, runObserver } from "../observer.js";
 import { CompactionProgressTracker } from "../progress.js";
 import type { Runtime } from "../runtime.js";
 import { serializeSourceAddressedBranchEntries } from "../serialize.js";
-import { estimateStringTokens } from "../tokens.js";
+import { estimateEntryTokens, estimateStringTokens } from "../tokens.js";
 import {
 	OBSERVATION_CUSTOM_TYPE,
 	reflectionToPromptLine,
@@ -49,6 +52,83 @@ function formatReflectorStats(stats: ReflectorStats): string {
 
 function formatPrunerStats(result: PrunerResult): string {
 	return `pruner dropped ${plural(result.droppedIds.length, "observation")} in ${plural(result.passes.length, "pass", "passes")}, stop: ${result.stopReason}`;
+}
+
+type EntryLike = Parameters<typeof estimateEntryTokens>[0] & { id: string };
+
+/**
+ * A message entry whose role can be inspected.
+ */
+type MessageEntry = EntryLike & { type: "message"; message?: { role?: string } };
+
+/**
+ * Returns true if the entry is a message with role "user" — the start of a new turn.
+ * In Pi's branch, a turn = user message + assistant response (with tool calls).
+ */
+function isTurnStart(entry: EntryLike): boolean {
+	if (entry.type !== "message") return false;
+	const e = entry as MessageEntry;
+	return (e.message as { role?: string })?.role === "user";
+}
+
+/**
+ * Split gap entries into batches that mimic active mode's turn_end observer trigger.
+ *
+ * Active mode fires at `turn_end` when rawTokensSinceLastBound >= threshold.
+ * Each trigger observes everything accumulated since the last boundary.
+ * The chunk is naturally bounded because the observer runs frequently.
+ *
+ * This function replicates that pattern for the passive-mode catch-up:
+ * 1. Split entries into turns (at user-role message boundaries)
+ * 2. Accumulate turns until total tokens >= threshold (same gate as active mode)
+ * 3. Emit that accumulated batch as one chunk
+ * 4. Repeat for remaining turns
+ *
+ * If the very first turn already exceeds the threshold, it is emitted alone
+ * (we never skip entries). If remaining turns total less than the threshold,
+ * they form a final chunk that will be observed (rather than deferred —
+ * unlike the loop-level threshold check which defers sub-threshold remainders).
+ */
+function batchByTurnsAndThreshold(gap: EntryLike[], thresholdTokens: number): EntryLike[][] {
+	if (gap.length === 0) return [];
+
+	// Step 1: split into individual turns
+	const turns: EntryLike[][] = [];
+	let currentTurn: EntryLike[] = [];
+
+	for (const entry of gap) {
+		if (isTurnStart(entry) && currentTurn.length > 0) {
+			turns.push(currentTurn);
+			currentTurn = [];
+		}
+		currentTurn.push(entry);
+	}
+	if (currentTurn.length > 0) turns.push(currentTurn);
+
+	// Step 2: accumulate turns into threshold-gated batches
+	// This mirrors active mode: accumulate turns until threshold is met, then observe.
+	const batches: EntryLike[][] = [];
+	let batch: EntryLike[] = [];
+	let batchTokens = 0;
+
+	for (const turn of turns) {
+		const turnTokens = turn.reduce((sum, e) => sum + estimateEntryTokens(e), 0);
+
+		batch.push(...turn);
+		batchTokens += turnTokens;
+
+		// Emit batch when threshold is reached (same gate as active mode's turn_end check)
+		if (batchTokens >= thresholdTokens) {
+			batches.push(batch);
+			batch = [];
+			batchTokens = 0;
+		}
+	}
+
+	// Remaining turns below threshold — still emit as final batch so they get observed
+	if (batch.length > 0) batches.push(batch);
+
+	return batches;
 }
 
 export function registerCompactionHook(pi: ExtensionAPI, runtime: Runtime): void {
@@ -130,73 +210,118 @@ export function registerCompactionHook(pi: ExtensionAPI, runtime: Runtime): void
 				reflections: memoryState.reflections.length,
 			});
 
-			let gapObservationData: ObservationEntryData | null = null;
+			// --- Sync catch-up observer: replay the active-mode observer loop ---
+			//
+			// Active mode flow:
+			//   turn_end fires → check rawTokensSinceLastBound >= threshold → observe
+			//   everything from last boundary to leaf → append entry → boundary advances
+			//
+			// Passive mode replay:
+			//   1. Get the gap (raw entries about to be compacted away)
+			//   2. Split gap into turns (at user-role message boundaries)
+			//   3. Accumulate turns until threshold is met (same gate as active mode)
+			//   4. Observe that batch — same as what active mode would have done at turn_end
+			//   5. Append entry with coversFromId/coversUpToId → boundary advances
+			//   6. Repeat for remaining batches
 			const gap = gapRawEntries(entries, firstKeptEntryId);
+
 			if (gap.length > 0) {
-				const { text: gapChunk, sourceEntryIds } = serializeSourceAddressedBranchEntries(gap);
-				if (gapChunk.trim() && sourceEntryIds.length > 0) {
-					const gapFromId = gap[0].id;
-					const gapUpToId = gap[gap.length - 1].id;
-					const priorObservationLines = observationsToPromptLines([
-						...memoryState.committedObs,
-						...memoryState.pendingObs,
-					]);
-					const gapTokenEstimate = estimateStringTokens(gapChunk);
-					debugLog("compaction.sync_catchup.start", {
-						gapEntryCount: gap.length,
-						sourceEntryIds,
-						gapFromId,
-						gapUpToId,
-						tokenEstimate: gapTokenEstimate,
-					});
-					if (hasUI) ui?.notify(
-						`Observational memory: sync catch-up observer running on ~${gapTokenEstimate.toLocaleString()}-token gap`,
-						"info",
-					);
-					progress.setPhase("observer", 1, 1);
-					updateWidget();
+				const gapEndId = gap[gap.length - 1].id;
+				const gapTokenEstimate = gap.reduce((sum, e) => sum + estimateEntryTokens(e), 0);
+
+				// Pre-compute batches upfront so we can show accurate progress (pass N/total)
+				const batches = batchByTurnsAndThreshold(gap as EntryLike[], runtime.config.observationThresholdTokens);
+
+				debugLog("compaction.sync_catchup.start", {
+					gapEntryCount: gap.length,
+					gapFromId: gap[0].id,
+					gapUpToId: gapEndId,
+					tokenEstimate: gapTokenEstimate,
+					batchCount: batches.length,
+				});
+				if (hasUI) ui?.notify(
+					`Observational memory: sync catch-up observer running on ~${gapTokenEstimate.toLocaleString()}-token gap in ${batches.length} batch${batches.length === 1 ? "" : "es"}`,
+					"info",
+				);
+
+				if (batches.length > 0) {
 					runtime.observerInFlight = true;
-					const gapCall = runObserver({
-						model: resolved.model as any,
-						apiKey: resolved.apiKey,
-						headers: resolved.headers,
-						priorReflections: memoryState.reflections.map(reflectionToPromptLine),
-						priorObservations: priorObservationLines,
-						chunk: gapChunk,
-						allowedSourceEntryIds: sourceEntryIds,
-						signal,
-						maxTurns: turnLimits.observerMaxTurnsPerRun,
-						thinkingLevel: runtime.config.thinkingLevel,
-					});
-					const gapPromise: Promise<void> = gapCall.then(() => undefined, () => undefined);
-					runtime.observerPromise = gapPromise;
 					try {
-						const records = await gapCall;
-						if (records && records.length > 0) {
-							const observationTokens = records.reduce((sum, r) => sum + estimateStringTokens(r.content), 0);
-							gapObservationData = {
-								records,
-								coversFromId: gapFromId,
-								coversUpToId: gapUpToId,
-								tokenCount: observationTokens,
-							};
-							debugLog("compaction.sync_catchup.records", {
-								count: records.length,
-								observationTokens,
-								coversFromId: gapFromId,
-								coversUpToId: gapUpToId,
-								records,
-							});
-							pi.appendEntry(OBSERVATION_CUSTOM_TYPE, gapObservationData);
-							if (hasUI && ui) ui.notify(
-								`Observational memory: sync catch-up recorded ${records.length} observation${records.length === 1 ? "" : "s"} (~${observationTokens.toLocaleString()} tokens)`,
-								"info",
+						for (let batchIdx = 0; batchIdx < batches.length; batchIdx++) {
+							// Refresh entries — previous iteration may have appended an observation entry
+							entries = ctx.sessionManager.getBranch() as typeof entries;
+
+							const batch = batches[batchIdx];
+							const chunkCoversFromId = batch[0].id;
+							const chunkCoversUpToId = batch[batch.length - 1].id;
+
+							const { text: chunkText, sourceEntryIds } = serializeSourceAddressedBranchEntries(
+								batch as Parameters<typeof serializeSourceAddressedBranchEntries>[0],
 							);
-						} else if (hasUI && ui) {
-							debugLog("compaction.sync_catchup.empty", { gapEntryCount: gap.length });
+							if (!chunkText.trim() || sourceEntryIds.length === 0) continue;
+
+							const passNum = batchIdx + 1;
+							progress.setPhase("observer", passNum, batches.length);
+							updateWidget();
+
+							const batchTokens = batch.reduce((sum, e) => sum + estimateEntryTokens(e), 0);
+							debugLog("compaction.sync_catchup.pass.start", {
+								pass: passNum,
+								totalPasses: batches.length,
+								coversFromId: chunkCoversFromId,
+								coversUpToId: chunkCoversUpToId,
+								batchEntryCount: batch.length,
+								batchTokens,
+							});
+
+							// Same prior context as observer-trigger.ts
+							const currentMemoryState = getMemoryState(entries);
+							const priorObservationLines = observationsToPromptLines([
+								...currentMemoryState.committedObs,
+								...currentMemoryState.pendingObs,
+							]);
+
+							const records = await runObserver({
+								model: resolved.model as any,
+								apiKey: resolved.apiKey,
+								headers: resolved.headers,
+								priorReflections: currentMemoryState.reflections.map(reflectionToPromptLine),
+								priorObservations: priorObservationLines,
+								chunk: chunkText,
+								allowedSourceEntryIds: sourceEntryIds,
+								signal,
+								maxTurns: turnLimits.observerMaxTurnsPerRun,
+								thinkingLevel: runtime.config.thinkingLevel,
+							});
+
+							if (records && records.length > 0) {
+								const observationTokens = records.reduce((sum, r) => sum + estimateStringTokens(r.content), 0);
+								const data: ObservationEntryData = {
+									records,
+									coversFromId: chunkCoversFromId,
+									coversUpToId: chunkCoversUpToId,
+									tokenCount: observationTokens,
+								};
+								pi.appendEntry(OBSERVATION_CUSTOM_TYPE, data);
+								debugLog("compaction.sync_catchup.pass.records", {
+									pass: passNum,
+									count: records.length,
+									observationTokens,
+									coversFromId: chunkCoversFromId,
+									coversUpToId: chunkCoversUpToId,
+								});
+							} else {
+								debugLog("compaction.sync_catchup.pass.empty", {
+									pass: passNum,
+									batchEntryCount: batch.length,
+								});
+							}
+						}
+
+						if (hasUI && ui) {
 							ui.notify(
-								"Observational memory: sync catch-up observer returned empty — proceeding with compaction",
-								"warning",
+								`Observational memory: sync catch-up completed ${batches.length} observer batch${batches.length === 1 ? "" : "es"}`,
+								"info",
 							);
 						}
 					} catch (error) {
@@ -209,7 +334,6 @@ export function registerCompactionHook(pi: ExtensionAPI, runtime: Runtime): void
 						return { cancel: true };
 					} finally {
 						runtime.observerInFlight = false;
-						if (runtime.observerPromise === gapPromise) runtime.observerPromise = null;
 					}
 				}
 			}
@@ -217,13 +341,11 @@ export function registerCompactionHook(pi: ExtensionAPI, runtime: Runtime): void
 			const priorCompactionIdx = findLastCompactionIndex(entries);
 			const priorFirstKeptEntryId = priorCompactionIdx >= 0 ? entries[priorCompactionIdx].firstKeptEntryId : undefined;
 			const deltaObservationData = collectObservationsByCoverage(entries, priorFirstKeptEntryId, firstKeptEntryId);
-			if (gapObservationData) deltaObservationData.push(gapObservationData);
 			debugLog("compaction.delta", {
 				priorFirstKeptEntryId,
 				firstKeptEntryId,
 				deltaObservationEntries: deltaObservationData.length,
 				deltaObservationRecords: deltaObservationData.reduce((sum, data) => sum + data.records.length, 0),
-				gapObservationRecords: gapObservationData?.records.length ?? 0,
 			});
 
 			if (deltaObservationData.length === 0) {

--- a/src/progress.ts
+++ b/src/progress.ts
@@ -44,11 +44,12 @@ export class CompactionProgressTracker {
 	}
 
 	setPhase(phase: CompactionPhase, pass: number, maxPasses: number): void {
-		if (this.phase && this.phase !== phase && !this.completedPhases.includes(this.phase)) {
-			this.completedPhases.push(this.phase);
+		const prevPhase = this.phase;
+		if (prevPhase && prevPhase !== phase && !this.completedPhases.includes(prevPhase)) {
+			this.completedPhases.push(prevPhase);
 		}
 		// Reset deltas when transitioning to a different phase
-		if (this.phase !== phase) {
+		if (prevPhase !== phase) {
 			this.reflectionsAdded = 0;
 			this.reflectionsMerged = 0;
 			this.observationsDropped = 0;
@@ -56,8 +57,12 @@ export class CompactionProgressTracker {
 		this.phase = phase;
 		this.pass = pass;
 		this.maxPasses = maxPasses;
-		this.toolCallCount = 0;
-		this.turnCount = 0;
+		// Reset per-phase counters only when transitioning to a different phase,
+		// not when advancing pass/batch within the same phase
+		if (prevPhase !== phase) {
+			this.toolCallCount = 0;
+			this.turnCount = 0;
+		}
 	}
 
 	setStartingCounts(reflections: number, observations: number): void {
@@ -124,14 +129,17 @@ export class CompactionProgressTracker {
 		});
 		parts.push(phaseLabels.join(theme.fg("dim", " → ")));
 
-		// Pass info (only for multi-pass phases)
+		// Pass/batch info (only for multi-pass phases)
 		if (this.maxPasses > 1) {
-			parts.push(theme.fg("muted", `pass ${this.pass}/${this.maxPasses}`));
+			const label = this.phase === "observer" ? "batch" : "pass";
+			parts.push(theme.fg("muted", `${label} ${this.pass}/${this.maxPasses}`));
 		}
 
-		// Tool calls
-		const tcLabel = this.toolCallCount === 1 ? "tool call" : "tool calls";
-		parts.push(theme.fg("muted", `${this.toolCallCount} ${tcLabel}`));
+		// Tool calls (only shown when non-zero — observer batches don't feed events)
+		if (this.toolCallCount > 0) {
+			const tcLabel = this.toolCallCount === 1 ? "tool call" : "tool calls";
+			parts.push(theme.fg("muted", `${this.toolCallCount} ${tcLabel}`));
+		}
 
 		// Delta counters: R total(+accumulated), M total(+accumulated), O remaining(-accumulated)
 		const deltas: string[] = [];

--- a/tests/passive-gap-bug.test.ts
+++ b/tests/passive-gap-bug.test.ts
@@ -1,0 +1,272 @@
+/**
+ * Tests for gap detection after compaction in passive mode.
+ *
+ * Bug: observation entries from before compaction can have coversUpToId values
+ * pointing to entries before the compaction boundary. gapRawEntries() would include
+ * all those already-compact entries in the gap, creating a massive chunk that
+ * exceeds the model's context window when passed to the sync catch-up observer.
+ *
+ * Fix: gapRawEntries() clamps the start boundary to at least the last compaction
+ * entry index, so only entries after the last compaction are included in the gap.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+const agentLoopMock = vi.hoisted(() => vi.fn());
+const codingAgentMock = vi.hoisted(() => ({ agentDir: "" }));
+
+vi.mock("@mariozechner/pi-agent-core", () => ({
+	agentLoop: agentLoopMock,
+}));
+
+vi.mock("@mariozechner/pi-coding-agent", () => ({
+	getAgentDir: () => codingAgentMock.agentDir,
+	estimateTokens: (msg: any) => {
+		if (typeof msg?.content === "string") return Math.ceil(msg.content.length / 4);
+		return 0;
+	},
+}));
+
+import { gapRawEntries, lastObservationCoverEndIdx } from "../src/branch.js";
+import { registerCompactionHook } from "../src/hooks/compaction-hook.js";
+import { estimateStringTokens } from "../src/tokens.js";
+import type { ObservationRecord } from "../src/types.js";
+import { compactionEntry, messageEntry, observationEntry } from "./fixtures/session.js";
+
+const observation: ObservationRecord = {
+	id: "abc123def456",
+	timestamp: "2026-05-02 10:30",
+	relevance: "high",
+	content: "User confirmed recall should use exact supporting source entry ids.",
+	sourceEntryIds: ["source-before-compact"],
+};
+
+function emptyAgentStream() {
+	return {
+		async *[Symbol.asyncIterator]() {},
+		result: async () => ({}),
+	};
+}
+
+describe("gap detection after compaction", () => {
+	it("lastObservationCoverEndIdx returns -1 when observation entries have dangling coversUpToId", () => {
+		const entries = [
+			compactionEntry({
+				id: "prior-compaction",
+				firstKeptEntryId: "kept-1",
+				details: {
+					type: "observational-memory",
+					version: 4,
+					observations: [observation],
+					reflections: [],
+				},
+			}),
+			messageEntry({ id: "kept-1", message: { role: "user", content: "kept tail message 1" } }),
+			messageEntry({ id: "kept-2", message: { role: "user", content: "kept tail message 2" } }),
+			// This observation entry survived compaction but its coversUpToId points to
+			// an entry that no longer exists in the branch
+			observationEntry({
+				id: "surviving-obs",
+				data: {
+					records: [observation],
+					coversFromId: "source-before-compact", // gone after compaction
+					coversUpToId: "source-before-compact", // gone after compaction
+					tokenCount: 100,
+				},
+			}),
+			messageEntry({ id: "kept-3", message: { role: "user", content: "more tail" } }),
+		];
+
+		const result = lastObservationCoverEndIdx(entries);
+		expect(result).toBe(-1);
+	});
+
+	it("gapRawEntries clamps to compaction entry when lastObservationCoverEndIdx is -1", () => {
+		const entries = [
+			compactionEntry({
+				id: "prior-compaction",
+				firstKeptEntryId: "kept-1",
+				details: {
+					type: "observational-memory",
+					version: 4,
+					observations: [observation],
+					reflections: [],
+				},
+			}),
+			messageEntry({ id: "kept-1", message: { role: "user", content: "a".repeat(1000) } }),
+			messageEntry({ id: "kept-2", message: { role: "user", content: "b".repeat(1000) } }),
+			messageEntry({ id: "kept-3", message: { role: "user", content: "c".repeat(1000) } }),
+			messageEntry({ id: "new-boundary", message: { role: "user", content: "d".repeat(1000) } }),
+			messageEntry({ id: "kept-5", message: { role: "user", content: "e".repeat(1000) } }),
+		];
+
+		// lastBoundIdx = -1, clamped to compaction entry index = 0
+		// gap = entries from index 1 to "new-boundary"-1 = kept-1, kept-2, kept-3
+		const gap = gapRawEntries(entries, "new-boundary");
+
+		expect(gap.length).toBe(3);
+		expect(gap.map((e) => e.id)).toEqual(["kept-1", "kept-2", "kept-3"]);
+	});
+
+	it("gapRawEntries excludes entries before compaction when observation cover is pre-compaction", () => {
+		// Scenario: observation entry exists BEFORE the compaction entry with a valid
+		// coversUpToId pointing to an entry that also exists before compaction.
+		// Without the fix, the gap would include all entries from the observation cover
+		// to the new boundary — including the pre-compaction entries that are already
+		// represented in the compaction details.
+		const entries = [
+			// Pre-compaction entries (already represented in compaction details)
+			messageEntry({ id: "old-source", message: { role: "user", content: "old content" } }),
+			messageEntry({ id: "old-source-2", message: { role: "user", content: "more old content" } }),
+			// Observation entry from previous sync catch-up — coversUpToId points to pre-compaction entry
+			observationEntry({
+				id: "old-obs",
+				data: {
+					records: [observation],
+					coversFromId: "old-source",
+					coversUpToId: "old-source-2", // valid — entry exists in branch
+					tokenCount: 100,
+				},
+			}),
+			// Compaction entry — marks boundary between compact and live
+			compactionEntry({
+				id: "prior-compaction",
+				firstKeptEntryId: "kept-1",
+				details: {
+					type: "observational-memory",
+					version: 4,
+					observations: [observation],
+					reflections: [],
+				},
+			}),
+			// Live tail entries — these are the ones that need observation
+			messageEntry({ id: "kept-1", message: { role: "user", content: "live content 1" } }),
+			messageEntry({ id: "kept-2", message: { role: "user", content: "live content 2" } }),
+			messageEntry({ id: "kept-3", message: { role: "user", content: "live content 3" } }),
+			messageEntry({ id: "new-boundary", message: { role: "user", content: "boundary" } }),
+			messageEntry({ id: "tail", message: { role: "user", content: "kept recent" } }),
+		];
+
+		// Without fix: lastBoundIdx = index of "old-source-2" = 1
+		//   gap would be entries from index 2 to "new-boundary"-1 = 6
+		//   That's [old-obs, prior-compaction, kept-1, kept-2, kept-3] — includes compacted entries!
+		//
+		// With fix: lastBoundIdx clamped to compaction entry index = 3
+		//   gap = entries from index 4 to "new-boundary"-1 = 6
+		//   That's [kept-1, kept-2, kept-3] — only live tail entries
+		const gap = gapRawEntries(entries, "new-boundary");
+
+		expect(gap.length).toBe(3);
+		expect(gap.map((e) => e.id)).toEqual(["kept-1", "kept-2", "kept-3"]);
+		// Should NOT include pre-compaction entries
+		expect(gap.map((e) => e.id)).not.toContain("old-source");
+		expect(gap.map((e) => e.id)).not.toContain("old-source-2");
+	});
+
+	it("compaction hook passes only post-compaction gap to observer", async () => {
+		agentLoopMock.mockReset();
+		agentLoopMock.mockImplementation(() => emptyAgentStream());
+
+		let handler: ((event: unknown, ctx: unknown) => Promise<unknown>) | undefined;
+		const pi = {
+			on: vi.fn((eventName: string, cb: typeof handler) => {
+				expect(eventName).toBe("session_before_compact");
+				handler = cb;
+			}),
+			appendEntry: vi.fn(),
+		};
+		const runtime = {
+			compactHookInFlight: false,
+			observerPromise: null,
+			resolveFailureNotified: false,
+			config: {
+				observationThresholdTokens: 1,
+				compactionThresholdTokens: 50_000,
+				reflectionThresholdTokens: 30_000,
+				passive: true,
+				debugLog: false,
+			},
+			ensureConfig: vi.fn(),
+			resolveModel: vi.fn(async () => ({ ok: true, model: {}, apiKey: "test-key" })),
+		};
+		registerCompactionHook(pi as never, runtime as never);
+		if (!handler) throw new Error("session_before_compact handler was not registered");
+
+		// Simulate a realistic branch: pre-compaction entries with observation cover,
+		// then compaction entry, then live tail that needs observation.
+		const entries = [
+			// Pre-compaction entries (content already in compaction details)
+			messageEntry({ id: "old-source", message: { role: "user", content: "old".repeat(500) } }),
+			messageEntry({ id: "old-source-2", message: { role: "user", content: "old2".repeat(500) } }),
+			observationEntry({
+				id: "old-obs",
+				data: {
+					records: [observation],
+					coversFromId: "old-source",
+					coversUpToId: "old-source-2",
+					tokenCount: 100,
+				},
+			}),
+			compactionEntry({
+				id: "prior-compaction",
+				firstKeptEntryId: "kept-1",
+				details: {
+					type: "observational-memory",
+					version: 4,
+					observations: [observation],
+					reflections: [],
+				},
+			}),
+			// Live tail — these need sync catch-up observation
+			messageEntry({ id: "kept-1", message: { role: "user", content: "start of kept tail" } }),
+			...Array.from({ length: 10 }, (_, i) =>
+				messageEntry({
+					id: `raw-${i}`,
+					message: { role: "user", content: `Message ${i} content` },
+				})
+			),
+			messageEntry({ id: "new-boundary", message: { role: "user", content: "boundary" } }),
+			messageEntry({ id: "tail", message: { role: "user", content: "kept tail" } }),
+		];
+
+		const notify = vi.fn();
+		const result = await handler({
+			preparation: { firstKeptEntryId: "new-boundary", tokensBefore: 50000 },
+			branchEntries: entries,
+			signal: undefined,
+		}, {
+			cwd: "/tmp/project",
+			hasUI: true,
+			ui: { notify, setWidget: vi.fn() },
+			sessionManager: { getBranch: vi.fn(() => entries) },
+		});
+
+		// The observer was called — at least once for the first turn-aligned chunk
+		expect(agentLoopMock).toHaveBeenCalled();
+
+		// Collect all observer prompt texts across all calls
+		const allPromptTexts = agentLoopMock.mock.calls
+			.map((call) => {
+				const prompts = call[0] as Array<{ content: Array<{ text: string }> }>;
+				return prompts[0]?.content?.[0]?.text ?? "";
+			})
+			.filter((text) => text.includes("NEW CONVERSATION CHUNK"));
+
+		// Verify that the first chunk contains the first turn (kept-1)
+		// and does NOT contain pre-compaction entries
+		expect(allPromptTexts.length).toBeGreaterThanOrEqual(1);
+		expect(allPromptTexts[0]).toContain("kept-1");
+
+		// Verify pre-compaction entries are NOT in any chunk
+		const combinedText = allPromptTexts.join("\n");
+		expect(combinedText).not.toContain("old-source");
+		expect(combinedText).not.toContain("old2");
+
+		// Note: the mock agentLoop produces no tool calls, so runObserver returns
+		// undefined (no records). The loop breaks after the first empty result.
+		// In production, each turn-aligned chunk that produces records would get
+		// its own appendEntry call and the loop would continue to the next turn.
+
+		// Verify compaction succeeded
+		expect(result).toHaveProperty("compaction");
+	});
+});

--- a/tests/passive-gap-bug.test.ts
+++ b/tests/passive-gap-bug.test.ts
@@ -26,7 +26,7 @@ vi.mock("@mariozechner/pi-coding-agent", () => ({
 	},
 }));
 
-import { gapRawEntries, lastObservationCoverEndIdx } from "../src/branch.js";
+import { gapRawEntries, lastObservationCoverEndIdx, rawTokensSinceLastBound } from "../src/branch.js";
 import { registerCompactionHook } from "../src/hooks/compaction-hook.js";
 import { estimateStringTokens } from "../src/tokens.js";
 import type { ObservationRecord } from "../src/types.js";
@@ -268,5 +268,40 @@ describe("gap detection after compaction", () => {
 
 		// Verify compaction succeeded
 		expect(result).toHaveProperty("compaction");
+	});
+
+	it("rawTokensSinceLastBound clamps to compaction entry when observation coversUpToId is dangling", () => {
+		const entries = [
+			compactionEntry({
+				id: "prior-compaction",
+				firstKeptEntryId: "kept-1",
+				details: {
+					type: "observational-memory",
+					version: 4,
+					observations: [observation],
+					reflections: [],
+				},
+			}),
+			messageEntry({ id: "kept-1", message: { role: "user", content: "a".repeat(1000) } }),
+			messageEntry({ id: "kept-2", message: { role: "user", content: "b".repeat(1000) } }),
+			// Observation entry with dangling coversUpToId — the referenced entry was compacted away
+			observationEntry({
+				id: "surviving-obs",
+				data: {
+					records: [observation],
+					coversFromId: "source-gone",
+					coversUpToId: "source-gone",
+					tokenCount: 100,
+				},
+			}),
+			messageEntry({ id: "kept-3", message: { role: "user", content: "c".repeat(1000) } }),
+		];
+
+		// Without clamping: lastObservationCoverEndIdx returns -1, rawTokensSinceLastBound
+		// counts ALL raw tokens in the branch (~3000 chars = ~750 tokens)
+		// With clamping: starts from compaction entry, counts only post-compaction raw tokens
+		const tokens = rawTokensSinceLastBound(entries);
+		const perMsg = Math.ceil(1000 / 4); // estimateTokens for each 1000-char message
+		expect(tokens).toBe(perMsg * 3); // kept-1, kept-2, kept-3 — not the entire branch
 	});
 });

--- a/tests/progress.test.ts
+++ b/tests/progress.test.ts
@@ -95,6 +95,26 @@ describe("CompactionProgressTracker", () => {
 		expect(text).toContain("Observer");
 	});
 
+	it("shows 'batch N/M' for observer phase with multiple batches", () => {
+		const tracker = new CompactionProgressTracker();
+		tracker.setPhase("observer", 3, 15);
+		const text = tracker.formatWidget({
+			fg: (_c: string, t: string) => t,
+		});
+		expect(text).toContain("batch 3/15");
+		expect(text).not.toContain("pass");
+	});
+
+	it("shows 'pass N/M' for reflector phase with multiple passes", () => {
+		const tracker = new CompactionProgressTracker();
+		tracker.setPhase("reflector", 2, 3);
+		const text = tracker.formatWidget({
+			fg: (_c: string, t: string) => t,
+		});
+		expect(text).toContain("pass 2/3");
+		expect(text).not.toContain("batch");
+	});
+
 	it("resets counts when phase changes", () => {
 		const tracker = new CompactionProgressTracker();
 		tracker.setPhase("reflector", 1, 3);
@@ -143,11 +163,12 @@ describe("CompactionProgressTracker", () => {
 		expect(text).toContain("Reflector"); // active
 	});
 
-	it("uses singular 'tool call' for 1 and plural for 0 or 2+", () => {
+	it("uses singular 'tool call' for 1 and plural for 2+", () => {
 		const tracker = new CompactionProgressTracker();
 		tracker.setPhase("reflector", 1, 3);
 		let text = tracker.formatWidget({ fg: (_c: string, t: string) => t });
-		expect(text).toContain("0 tool calls");
+		// Tool calls hidden when 0 (observer batches don't feed events)
+		expect(text).not.toContain("tool call");
 		tracker.onEvent({ type: "tool_execution_start", toolCallId: "tc1", toolName: "r", args: {} });
 		text = tracker.formatWidget({ fg: (_c: string, t: string) => t });
 		expect(text).toContain("1 tool call");


### PR DESCRIPTION
### What

Three bugs in passive-mode compaction and status display:

1. **`gapRawEntries()` included pre-compaction entries** — observation entries with `coversUpToId` pointing to already-compacted-away entries caused the gap to start from index 0, pulling in the entire raw conversation tail (hundreds of thousands of tokens) on every compaction.

2. **Sync catch-up observer sent the entire gap as one unchunked LLM call** — the oversized gap either exceeded the model's context window (compaction failed silently) or was processed with massive token usage, producing duplicate observations since the same raw content was re-observed from scratch on every compaction.

3. **`rawTokensSinceLastBound()` showed phantom ~539K unobserved tokens** — same dangling `coversUpToId` problem in the status display function caused `/om-status` to show observation trigger at 100% even though the actual post-compaction gap was tiny and already observed.

### Why

In passive mode, the observer trigger is disabled — no `turn_end` fires. Observation processing relies entirely on the compaction hook's sync catch-up. When that catch-up sent the entire accumulated gap (growing with every conversation turn) as a single LLM call, compaction either:
- Failed with context overflow (observations never processed), or
- Succeeded with enormous token usage (provider cost spike), producing duplicate/overlapping observations since the same raw content was re-observed from scratch on every compaction cycle.

The status display amplified the confusion by showing 539K unobserved tokens at 100%, making it look like observations were never compacted when in reality the 235 committed observations (~19K tokens) were healthy.

### How

- **Clamp `gapRawEntries()`** — start boundary is `max(lastObservationCoverEndIdx, findLastCompactionIndex)`, ensuring the gap only includes post-compaction entries (~20K tokens, not ~500K).

- **Clamp `rawTokensSinceLastBound()`** — same clamping for the status display, so `/om-status` shows the real post-compaction tail size instead of the phantom full-branch count.

- **Replay active mode's exact observer loop** in the compaction hook: split the gap into turns at user-role message boundaries, accumulate turns until `observationThresholdTokens` is reached (same gate as active mode's `turn_end` check), run `runObserver` per batch, append individual observation entries with per-chunk `coversFromId`/`coversUpToId`. Batches are pre-computed so progress shows a fixed total.

- **Progress widget improvements**: observer phase shows `batch N/M` (not `pass`), tool call count hidden when 0 (observer batches don't feed events to the tracker), counters preserved across batches within the same phase.

**Commits:**
- `3e0857c` — fix gap clamping, chunked sync catch-up observer, progress widget improvements
- `354758a` — fix `rawTokensSinceLastBound` clamping for status display

**Files changed**: `src/branch.ts` (+22/−2), `src/hooks/compaction-hook.ts` (+254/−74), `src/progress.ts` (+28/−5), `tests/passive-gap-bug.test.ts` (new, +307), `tests/progress.test.ts` (+25/−2).

Evidence from prior to fix:
```
 ── Mode ──
 Passive: proactive observation and compaction triggers disabled; compaction hook remains active

 ── Memory ──
 Reflections:   ~0 tokens (0 entries)      — durable insights
 Observations:
   committed    ~19 308 tokens (235 observations) — folded into last compaction
   pending      ~0 tokens (0 observations) — waiting for next compaction
   relevance    critical: 3 · high: 99 · medium: 97 · low: 36

 ── Activity ──
 Observation trigger: passive (~536 855 / 1000 tokens, 100%)
   → proactive observation is disabled; manual/Pi compaction can still run sync catch-up observation
 Compaction trigger:  passive (~23 577 / 50 000 tokens, 47%)
   → proactive extension-triggered compaction is disabled; manual/Pi compaction still uses the custom hook
 Next reflection:     ~19 308 / 30 000 tokens (64%)
   → if observations exceed 30 000 tokens when compaction runs, reflections are
     distilled from them and redundant observations are pruned away
```

and errors for local model as observer in vllm:
```
(APIServer pid=1115084) ERROR 05-16 22:03:19 [api_router.py:72] vllm.exceptions.VLLMValidationError: This model's maximum context length is 262144 tokens. However, you requested 32000 output tokens and your prompt contains at least 230145 input tokens, for a total of at least 262145 tokens. Please reduce the length of the input prompt or the number of requested output tokens. (parameter=input_tokens, value=230145)
```