### PR TITLE
Improve memory compaction pruning controls

### DIFF
--- a/src/commands/native-compact.ts
+++ b/src/commands/native-compact.ts
@@ -1,0 +1,30 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { Runtime } from "../runtime.js";
+
+export function registerNativeCompactCommand(pi: ExtensionAPI, runtime: Runtime): void {
+	pi.registerCommand("om-compact-native", {
+		description: "Run one normal Pi compaction, bypassing observational memory for this compaction only",
+		handler: async (args, ctx) => {
+			runtime.bypassNextCompactionHook = true;
+			const customInstructions = args.trim() || undefined;
+			ctx.ui.notify(
+				"Observational memory: bypassing the custom compaction hook once; running normal Pi compaction",
+				"info",
+			);
+			ctx.compact({
+				customInstructions,
+				onComplete: () => {
+					runtime.bypassNextCompactionHook = false;
+					ctx.ui.notify(
+						"Observational memory: normal Pi compaction completed; future compactions will use observational memory again",
+						"info",
+					);
+				},
+				onError: (error) => {
+					runtime.bypassNextCompactionHook = false;
+					ctx.ui.notify(`Observational memory: normal Pi compaction failed: ${error.message}`, "warning");
+				},
+			});
+		},
+	});
+}

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -94,11 +94,12 @@ export function registerStatusCommand(pi: ExtensionAPI, runtime: Runtime): void 
 				...activityLines,
 			];
 
-			if (runtime.observerInFlight || runtime.compactInFlight) {
+			if (runtime.observerInFlight || runtime.compactInFlight || runtime.bypassNextCompactionHook) {
 				lines.push("");
 				lines.push("── In flight ──");
 				if (runtime.observerInFlight) lines.push("Observer: running");
 				if (runtime.compactInFlight) lines.push("Compaction: running");
+				if (runtime.bypassNextCompactionHook) lines.push("Next compaction: bypass observational memory hook once");
 			}
 
 			ctx.ui.notify(lines.join("\n"), "info");

--- a/src/compaction.ts
+++ b/src/compaction.ts
@@ -13,10 +13,49 @@ import type { MemoryReflection, ObservationRecord, ReflectionRecord } from "./ty
 
 export const REFLECTOR_MAX_PASSES = 2;
 export const PRUNER_MAX_PASSES = 2;
-const PRUNER_TARGET_RATIO = 0.8;
+export const PRUNER_TARGET_RATIO = 0.8;
+
+const RELEVANCE_DROP_ORDER: Record<ObservationRecord["relevance"], number> = {
+	low: 0,
+	medium: 1,
+	high: 2,
+	critical: 3,
+};
 
 export function observationPoolTokens(observations: ObservationRecord[]): number {
+	// Use the rendered observation lines, not only bare content. The compaction
+	// summary includes id/timestamp/relevance metadata for every observation, and
+	// short observations can otherwise look cheap enough to skip pruning while the
+	// actual summary grows large enough to keep the actor near the context limit.
 	return estimateStringTokens(observationsToPromptLines(observations).join("\n"));
+}
+
+export function pruneObservationsDeterministically(
+	observations: ObservationRecord[],
+	budgetTokens: number,
+): { observations: ObservationRecord[]; droppedIds: string[] } {
+	if (observations.length === 0 || observationPoolTokens(observations) <= budgetTokens) {
+		return { observations, droppedIds: [] };
+	}
+
+	const dropped = new Set<string>();
+	const candidates = observations
+		.filter((o) => o.relevance !== "critical")
+		.map((observation, index) => ({ observation, index }))
+		.sort((a, b) => {
+			const relevanceDelta = RELEVANCE_DROP_ORDER[a.observation.relevance] - RELEVANCE_DROP_ORDER[b.observation.relevance];
+			if (relevanceDelta !== 0) return relevanceDelta;
+			return a.index - b.index;
+		});
+
+	let kept = observations;
+	for (const { observation } of candidates) {
+		dropped.add(observation.id);
+		kept = observations.filter((o) => !dropped.has(o.id));
+		if (observationPoolTokens(kept) <= budgetTokens) break;
+	}
+
+	return { observations: kept, droppedIds: Array.from(dropped) };
 }
 
 interface LlmArgs {

--- a/src/hooks/compaction-hook.ts
+++ b/src/hooks/compaction-hook.ts
@@ -9,10 +9,12 @@ import {
 	getMemoryState,
 } from "../branch.js";
 import {
+	PRUNER_TARGET_RATIO,
 	REFLECTOR_MAX_PASSES,
 	coverageTagCounts,
 	migrateLegacyReflections,
 	observationPoolTokens,
+	pruneObservationsDeterministically,
 	renderSummary,
 	runPruner,
 	runReflector,
@@ -53,6 +55,15 @@ function formatPrunerStats(result: PrunerResult): string {
 
 export function registerCompactionHook(pi: ExtensionAPI, runtime: Runtime): void {
 	pi.on("session_before_compact", async (event, ctx) => {
+		if (runtime.bypassNextCompactionHook) {
+			runtime.bypassNextCompactionHook = false;
+			if (ctx.hasUI) ctx.ui.notify(
+				"Observational memory: skipped custom compaction hook once; normal Pi compaction will run",
+				"info",
+			);
+			return;
+		}
+
 		if (runtime.compactHookInFlight) {
 			if (ctx.hasUI) ctx.ui.notify(
 				"Observational memory: another compaction is already in progress; cancelling duplicate",
@@ -273,7 +284,7 @@ export function registerCompactionHook(pi: ExtensionAPI, runtime: Runtime): void
 			}
 
 			const workingReflections: MemoryReflection[] = migrateLegacyReflections(memoryState.reflections);
-			const workingObservations: ObservationRecord[] = [
+			let workingObservations: ObservationRecord[] = [
 				...memoryState.committedObs,
 				...deltaObservationData.flatMap((d) => d.records),
 			];
@@ -291,6 +302,16 @@ export function registerCompactionHook(pi: ExtensionAPI, runtime: Runtime): void
 			let finalObservations = workingObservations;
 
 			if (observationTokens >= runtime.config.reflectionThresholdTokens) {
+				const deterministicBudget = Math.max(1, Math.floor(runtime.config.reflectionThresholdTokens * PRUNER_TARGET_RATIO));
+				const deterministicResult = pruneObservationsDeterministically(workingObservations, deterministicBudget);
+				if (deterministicResult.droppedIds.length > 0) {
+					workingObservations = deterministicResult.observations;
+					finalObservations = workingObservations;
+					if (hasUI) ui?.notify(
+						`Observational memory: pre-pruned ${deterministicResult.droppedIds.length} low/older observation${deterministicResult.droppedIds.length === 1 ? "" : "s"} before reflection`,
+						"info",
+					);
+				}
 				try {
 					debugLog("compaction.reflect_prune.start", {
 						workingObservations: workingObservations.length,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { registerNativeCompactCommand } from "./commands/native-compact.js";
 import { registerStatusCommand } from "./commands/status.js";
 import { registerViewCommand } from "./commands/view.js";
 import { registerCompactionHook } from "./hooks/compaction-hook.js";
@@ -16,5 +17,6 @@ export default function observationalMemory(pi: ExtensionAPI) {
 
 	registerStatusCommand(pi, runtime);
 	registerViewCommand(pi, runtime);
+	registerNativeCompactCommand(pi, runtime);
 	registerRecallTool(pi);
 }

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -26,6 +26,7 @@ export class Runtime {
 	observerPromise: Promise<void> | null = null;
 	compactInFlight = false;
 	compactHookInFlight = false;
+	bypassNextCompactionHook = false;
 	resolveFailureNotified = false;
 
 	ensureConfig(cwd: string): void {

--- a/tests/pruner.test.ts
+++ b/tests/pruner.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
 	deriveObservationCoverageTags,
 	observationPoolTokens,
+	pruneObservationsDeterministically,
 	renderObservationsForPrunerPrompt,
 	renderSummary,
 	runPruner,
@@ -107,6 +108,23 @@ describe("observation coverage tags", () => {
 		expect(tags.get(obsB.id)).toBe("cited");
 		expect(tags.get(obsC.id)).toBe("uncited");
 		expect(tags.has("aaaaaaaaaaaa")).toBe(false);
+	});
+
+	it("counts rendered observation metadata toward the pruning budget", () => {
+		const contentOnlyTokens = Math.ceil(observations.reduce((sum, obs) => sum + obs.content.length, 0) / 4);
+
+		expect(observationPoolTokens(observations)).toBeGreaterThan(contentOnlyTokens);
+	});
+
+	it("deterministically drops low and older non-critical observations to meet an emergency budget", () => {
+		const critical: ObservationRecord = { ...obsA, id: "444444444444", relevance: "critical" };
+		const oversized = [critical, obsA, obsB, obsC];
+		const keepCriticalOnlyBudget = observationPoolTokens([critical]);
+
+		const result = pruneObservationsDeterministically(oversized, keepCriticalOnlyBudget);
+
+		expect(result.observations).toEqual([critical]);
+		expect(result.droppedIds).toEqual([obsC.id, obsB.id, obsA.id]);
 	});
 
 	it("renders coverage tags only in pruner observation prompts", () => {

--- a/tests/recall-tool.test.ts
+++ b/tests/recall-tool.test.ts
@@ -91,7 +91,7 @@ describe("recall tool registration", () => {
 		observationalMemory(pi as never);
 
 		expect(pi.on).toHaveBeenCalledTimes(3);
-		expect(pi.registerCommand).toHaveBeenCalledTimes(2);
+		expect(pi.registerCommand).toHaveBeenCalledTimes(3);
 		expect(pi.registerTool).toHaveBeenCalledTimes(1);
 		expect(pi.registerTool.mock.calls[0][0].name).toBe(RECALL_OBSERVATION_TOOL_NAME);
 	});


### PR DESCRIPTION
This squashes the dataforxyz fork's local observational-memory changes onto current upstream master.\n\nHighlights:\n- count rendered observation metadata when budgeting observation pools\n- deterministically pre-prune low/older non-critical observations before reflector/pruner runs under pressure\n- add a native compaction bypass command so normal Pi compaction can run once\n\nValidation note: I resolved conflicts on top of current upstream master. Tests were not runnable in the temporary worktree because vitest was not installed there.