### PR TITLE
Rename @mariozechner/* imports to @earendil-works/*

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,16 +34,16 @@
     "test": "vitest run"
   },
   "peerDependencies": {
-    "@mariozechner/pi-agent-core": "*",
-    "@mariozechner/pi-ai": "*",
-    "@mariozechner/pi-coding-agent": "*",
-    "@mariozechner/pi-tui": "*"
+    "@earendil-works/pi-agent-core": "*",
+    "@earendil-works/pi-ai": "*",
+    "@earendil-works/pi-coding-agent": "*",
+    "@earendil-works/pi-tui": "*"
   },
   "devDependencies": {
-    "@mariozechner/pi-agent-core": "^0.73.0",
-    "@mariozechner/pi-ai": "^0.73.0",
-    "@mariozechner/pi-coding-agent": "^0.73.0",
-    "@mariozechner/pi-tui": "^0.73.0",
+    "@earendil-works/pi-agent-core": "^0.74.0",
+    "@earendil-works/pi-ai": "^0.74.0",
+    "@earendil-works/pi-coding-agent": "^0.74.0",
+    "@earendil-works/pi-tui": "^0.74.0",
     "@types/node": "^22.0.0",
     "typebox": "^1.1.38",
     "typescript": "^5.6.0",

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -1,5 +1,5 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import { SettingsManager } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { SettingsManager } from "@earendil-works/pi-coding-agent";
 import {
 	getMemoryState,
 	rawTokensSinceLastBound,

--- a/src/commands/view.ts
+++ b/src/commands/view.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { getMemoryState } from "../branch.js";
 import { observationPoolTokens as estimateObservationPoolTokens } from "../compaction.js";
 import { countByRelevance, formatRelevanceHistogram } from "../relevance.js";

--- a/src/compaction.ts
+++ b/src/compaction.ts
@@ -1,5 +1,5 @@
-import { agentLoop, type AgentContext, type AgentEvent, type AgentLoopConfig, type AgentTool } from "@mariozechner/pi-agent-core";
-import { Type, type Message, type Model, type ModelThinkingLevel } from "@mariozechner/pi-ai";
+import { agentLoop, type AgentContext, type AgentEvent, type AgentLoopConfig, type AgentTool } from "@earendil-works/pi-agent-core";
+import { Type, type Message, type Model, type ModelThinkingLevel } from "@earendil-works/pi-ai";
 import type { Static } from "typebox";
 import { debugLog, isDebugLogEnabled } from "./debug-log.js";
 import { hashId } from "./ids.js";
@@ -25,7 +25,7 @@ interface LlmArgs {
 	headers?: Record<string, string>;
 	signal?: AbortSignal;
 	agentLoop?: typeof agentLoop;
-	onEvent?: (event: import("@mariozechner/pi-agent-core").AgentEvent) => void;
+	onEvent?: (event: import("@earendil-works/pi-agent-core").AgentEvent) => void;
 	maxTurns?: number;
 	thinkingLevel?: ModelThinkingLevel;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-import type { ModelThinkingLevel } from "@mariozechner/pi-ai";
-import { getAgentDir } from "@mariozechner/pi-coding-agent";
+import type { ModelThinkingLevel } from "@earendil-works/pi-ai";
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
 
 export interface Config {
 	observationThresholdTokens: number;

--- a/src/debug-log.ts
+++ b/src/debug-log.ts
@@ -1,7 +1,7 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 import { existsSync, mkdirSync, renameSync, statSync, unlinkSync, appendFileSync } from "node:fs";
 import { dirname, join } from "node:path";
-import { getAgentDir } from "@mariozechner/pi-coding-agent";
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
 
 export const DEBUG_LOG_MAX_BYTES = 10 * 1024 * 1024;
 export const DEBUG_LOG_RELATIVE_PATH = join("observational-memory", "debug.ndjson");

--- a/src/hooks/compaction-hook.ts
+++ b/src/hooks/compaction-hook.ts
@@ -1,5 +1,5 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import { Text } from "@mariozechner/pi-tui";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { Text } from "@earendil-works/pi-tui";
 import { debugLog, withDebugLogContext } from "../debug-log.js";
 import { resolveTurnLimits } from "../config.js";
 import {

--- a/src/hooks/compaction-trigger.ts
+++ b/src/hooks/compaction-trigger.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { rawTokensSinceLastCompaction } from "../branch.js";
 import type { Runtime } from "../runtime.js";
 

--- a/src/hooks/observer-trigger.ts
+++ b/src/hooks/observer-trigger.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { debugLog, withDebugLogContext } from "../debug-log.js";
 import { resolveTurnLimits } from "../config.js";
 import {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { registerStatusCommand } from "./commands/status.js";
 import { registerViewCommand } from "./commands/view.js";
 import { registerCompactionHook } from "./hooks/compaction-hook.js";

--- a/src/model-budget.ts
+++ b/src/model-budget.ts
@@ -1,4 +1,4 @@
-import type { Model } from "@mariozechner/pi-ai";
+import type { Model } from "@earendil-works/pi-ai";
 
 export const AGENT_LOOP_MAX_TOKENS = 32_000;
 

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -1,6 +1,6 @@
-import { agentLoop, type AgentContext, type AgentLoopConfig, type AgentTool } from "@mariozechner/pi-agent-core";
-import type { Message, Model, ModelThinkingLevel } from "@mariozechner/pi-ai";
-import { Type } from "@mariozechner/pi-ai";
+import { agentLoop, type AgentContext, type AgentLoopConfig, type AgentTool } from "@earendil-works/pi-agent-core";
+import type { Message, Model, ModelThinkingLevel } from "@earendil-works/pi-ai";
+import { Type } from "@earendil-works/pi-ai";
 import type { Static } from "typebox";
 import { hashId } from "./ids.js";
 import { AGENT_LOOP_MAX_TOKENS, boundedMaxTokens } from "./model-budget.js";

--- a/src/progress.ts
+++ b/src/progress.ts
@@ -1,4 +1,4 @@
-import type { AgentEvent } from "@mariozechner/pi-agent-core";
+import type { AgentEvent } from "@earendil-works/pi-agent-core";
 
 export type CompactionPhase = "observer" | "reflector" | "pruner";
 

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -1,4 +1,4 @@
-import type { Message, TextContent, ToolResultMessage } from "@mariozechner/pi-ai";
+import type { Message, TextContent, ToolResultMessage } from "@earendil-works/pi-ai";
 
 function pad(n: number): string {
 	return n.toString().padStart(2, "0");

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -1,4 +1,4 @@
-import { estimateTokens as estimateMessageTokens } from "@mariozechner/pi-coding-agent";
+import { estimateTokens as estimateMessageTokens } from "@earendil-works/pi-coding-agent";
 
 export function estimateStringTokens(text: string): number {
 	return Math.ceil(text.length / 4);

--- a/src/tools/recall-observation.ts
+++ b/src/tools/recall-observation.ts
@@ -1,8 +1,8 @@
-import { Type } from "@mariozechner/pi-ai";
-import type { Message, ToolResultMessage } from "@mariozechner/pi-ai";
-import { defineTool, type ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import type { AgentToolResult } from "@mariozechner/pi-agent-core";
-import { Text } from "@mariozechner/pi-tui";
+import { Type } from "@earendil-works/pi-ai";
+import type { Message, ToolResultMessage } from "@earendil-works/pi-ai";
+import { defineTool, type ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import type { AgentToolResult } from "@earendil-works/pi-agent-core";
+import { Text } from "@earendil-works/pi-tui";
 import {
 	recallMemorySources,
 	type Entry,

--- a/tests/compaction.test.ts
+++ b/tests/compaction.test.ts
@@ -6,11 +6,11 @@ import { describe, expect, it, vi } from "vitest";
 const agentLoopMock = vi.hoisted(() => vi.fn());
 const codingAgentMock = vi.hoisted(() => ({ agentDir: "" }));
 
-vi.mock("@mariozechner/pi-agent-core", () => ({
+vi.mock("@earendil-works/pi-agent-core", () => ({
 	agentLoop: agentLoopMock,
 }));
 
-vi.mock("@mariozechner/pi-coding-agent", () => ({
+vi.mock("@earendil-works/pi-coding-agent", () => ({
 	getAgentDir: () => codingAgentMock.agentDir,
 }));
 

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mock = vi.hoisted(() => ({ agentDir: "" }));
 
-vi.mock("@mariozechner/pi-coding-agent", () => ({
+vi.mock("@earendil-works/pi-coding-agent", () => ({
 	getAgentDir: () => mock.agentDir,
 }));
 

--- a/tests/debug-log.test.ts
+++ b/tests/debug-log.test.ts
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mock = vi.hoisted(() => ({ agentDir: "" }));
 
-vi.mock("@mariozechner/pi-coding-agent", () => ({
+vi.mock("@earendil-works/pi-coding-agent", () => ({
 	getAgentDir: () => mock.agentDir,
 }));
 

--- a/tests/pruner-debug-log.test.ts
+++ b/tests/pruner-debug-log.test.ts
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mock = vi.hoisted(() => ({ agentDir: "" }));
 
-vi.mock("@mariozechner/pi-coding-agent", () => ({
+vi.mock("@earendil-works/pi-coding-agent", () => ({
 	getAgentDir: () => mock.agentDir,
 }));
 


### PR DESCRIPTION
Closes #14.

The pi packages were rebranded from `@mariozechner/*` to `@earendil-works/*` starting with version 0.74.0. Under recent pi releases, `pi-observational-memory` fails to load because its imports no longer resolve. This PR updates the package to the new scope.

### Changes

- Rewrite all `@mariozechner/*` imports across `src/` and `tests/` to `@earendil-works/*` (`pi-agent-core`, `pi-ai`, `pi-coding-agent`, `pi-tui`).
- Bump `devDependencies` from `^0.73.0` to `^0.74.0`. The `@earendil-works` scope has no 0.73.x release; 0.74.0 is the first published version.

### Verification

Tested under pi 0.74.1