### PR TITLE
fix(observer): advance coverage watermark when observer records nothing

### DIFF
--- a/src/hooks/consolidation-trigger.ts
+++ b/src/hooks/consolidation-trigger.ts
@@ -8,9 +8,12 @@ import { type ResolveResult, type Runtime } from "../runtime.js";
 import { serializeSourceAddressedBranchEntries } from "../serialize.js";
 import {
 	OM_OBSERVATIONS_DROPPED,
+	OM_OBSERVATIONS_NONE,
 	OM_OBSERVATIONS_RECORDED,
 	OM_REFLECTIONS_RECORDED,
+	OBSERVATION_COVERAGE_TYPES,
 	buildObservationsDroppedData,
+	buildObservationsNoneData,
 	buildObservationsRecordedData,
 	buildReflectionsRecordedData,
 	earlierCoverageMarkerId,
@@ -188,7 +191,7 @@ async function runObserverStage(
 	const tokens = rawTokensSinceObservationCoverage(entries);
 	if (tokens < runtime.config.observeAfterTokens) return "continue";
 
-	const lastCoverageIdx = latestCoverageIndex(entries, OM_OBSERVATIONS_RECORDED);
+	const lastCoverageIdx = latestCoverageIndex(entries, OBSERVATION_COVERAGE_TYPES);
 	const chunkEntries = sourceEntriesAfter(entries, lastCoverageIdx);
 	const coversUpToId = chunkEntries.at(-1)?.id;
 	if (!coversUpToId) return "continue";
@@ -228,10 +231,18 @@ async function runObserverStage(
 		thinkingLevel: runtime.config.model?.thinking ?? "low",
 	});
 	if (!observations || observations.length === 0) {
-		debugLog("observer.empty", { coversUpToId });
+		// The observer ran over this chunk and judged there was nothing worth
+		// recording. Persist a coverage-only marker so the watermark advances and
+		// the same span is not re-observed on every subsequent turn (which would
+		// otherwise spam the user and burn observer calls until something
+		// incidental finally sticks). Raw entries remain available to the
+		// reflector and until compaction, so no memory is lost.
+		const noneData = buildObservationsNoneData(coversUpToId);
+		if (noneData) appendEntry(pi, OM_OBSERVATIONS_NONE, noneData);
+		debugLog("observer.empty", { coversUpToId, coverageAdvanced: noneData !== undefined });
 		if (ctx.hasUI) ctx.ui?.notify(
-			"Observational memory: observer returned no observations",
-			"warning",
+			"Observational memory: observer found nothing new to record",
+			"info",
 		);
 		return "continue";
 	}

--- a/src/session-ledger/progress.ts
+++ b/src/session-ledger/progress.ts
@@ -1,11 +1,20 @@
 import { estimateEntryTokens } from "../tokens.js";
 import {
 	OM_OBSERVATIONS_DROPPED,
+	OM_OBSERVATIONS_NONE,
 	OM_OBSERVATIONS_RECORDED,
 	OM_REFLECTIONS_RECORDED,
 	type Entry,
 	type V3MemoryCustomType,
 } from "./types.js";
+
+// The observation coverage watermark advances on EITHER a recorded-observations
+// marker OR a coverage-only "none" marker (observer ran, recorded nothing). Both
+// mean "this span has been observed", so neither should be re-observed.
+export const OBSERVATION_COVERAGE_TYPES: V3MemoryCustomType[] = [
+	OM_OBSERVATIONS_RECORDED,
+	OM_OBSERVATIONS_NONE,
+];
 
 const SOURCE_ENTRY_TYPES = new Set(["message", "custom_message", "branch_summary"]);
 
@@ -38,17 +47,27 @@ function isValidCoverageEntry(entry: Entry, customType: V3MemoryCustomType): ent
 	if (!isObject(entry.data) || typeof entry.data.coversUpToId !== "string") return false;
 
 	if (customType === OM_OBSERVATIONS_RECORDED) return isNonEmptyArray(entry.data.observations);
+	if (customType === OM_OBSERVATIONS_NONE) return true; // coverage-only marker, no payload
 	if (customType === OM_REFLECTIONS_RECORDED) return isNonEmptyArray(entry.data.reflections);
 	return isNonEmptyArray(entry.data.observationIds);
 }
 
-export function latestCoverageIndex(entries: Entry[], customType: V3MemoryCustomType): number {
+function coverageCustomTypes(customType: V3MemoryCustomType | V3MemoryCustomType[]): V3MemoryCustomType[] {
+	return Array.isArray(customType) ? customType : [customType];
+}
+
+function matchesAnyCoverage(entry: Entry, types: V3MemoryCustomType[]): boolean {
+	return types.some((type) => isValidCoverageEntry(entry, type));
+}
+
+export function latestCoverageIndex(entries: Entry[], customType: V3MemoryCustomType | V3MemoryCustomType[]): number {
+	const types = coverageCustomTypes(customType);
 	const idToIndex = entryIndexById(entries);
 	let latest = -1;
 
 	for (const entry of entries) {
-		if (!isValidCoverageEntry(entry, customType)) continue;
-		const coveredIndex = idToIndex.get(entry.data.coversUpToId);
+		if (!matchesAnyCoverage(entry, types)) continue;
+		const coveredIndex = idToIndex.get((entry.data as { coversUpToId: string }).coversUpToId);
 		if (coveredIndex === undefined) continue;
 		if (coveredIndex > latest) latest = coveredIndex;
 	}
@@ -56,18 +75,20 @@ export function latestCoverageIndex(entries: Entry[], customType: V3MemoryCustom
 	return latest;
 }
 
-export function latestCoverageMarkerId(entries: Entry[], customType: V3MemoryCustomType): string | undefined {
+export function latestCoverageMarkerId(entries: Entry[], customType: V3MemoryCustomType | V3MemoryCustomType[]): string | undefined {
+	const types = coverageCustomTypes(customType);
 	const idToIndex = entryIndexById(entries);
 	let latestIndex = -1;
 	let latestMarkerId: string | undefined;
 
 	for (const entry of entries) {
-		if (!isValidCoverageEntry(entry, customType)) continue;
-		const coveredIndex = idToIndex.get(entry.data.coversUpToId);
+		if (!matchesAnyCoverage(entry, types)) continue;
+		const coversUpToId = (entry.data as { coversUpToId: string }).coversUpToId;
+		const coveredIndex = idToIndex.get(coversUpToId);
 		if (coveredIndex === undefined) continue;
 		if (coveredIndex > latestIndex) {
 			latestIndex = coveredIndex;
-			latestMarkerId = entry.data.coversUpToId;
+			latestMarkerId = coversUpToId;
 		}
 	}
 
@@ -94,12 +115,12 @@ export function rawTokensAfterIndex(entries: Entry[], index: number): number {
 	return total;
 }
 
-export function rawTokensSinceCoverage(entries: Entry[], customType: V3MemoryCustomType): number {
+export function rawTokensSinceCoverage(entries: Entry[], customType: V3MemoryCustomType | V3MemoryCustomType[]): number {
 	return rawTokensAfterIndex(entries, latestCoverageIndex(entries, customType));
 }
 
 export function rawTokensSinceObservationCoverage(entries: Entry[]): number {
-	return rawTokensSinceCoverage(entries, OM_OBSERVATIONS_RECORDED);
+	return rawTokensSinceCoverage(entries, OBSERVATION_COVERAGE_TYPES);
 }
 
 export function rawTokensSinceReflectionCoverage(entries: Entry[]): number {

--- a/src/session-ledger/types.ts
+++ b/src/session-ledger/types.ts
@@ -1,4 +1,9 @@
 export const OM_OBSERVATIONS_RECORDED = "om.observations.recorded";
+// Coverage-only marker: the observer ran over a chunk and recorded nothing.
+// It advances the observation coverage watermark (so the same span is not
+// re-observed every turn) without contributing any observations to the
+// projection. See buildObservationsNoneData / isObservationsNoneEntry.
+export const OM_OBSERVATIONS_NONE = "om.observations.none";
 export const OM_REFLECTIONS_RECORDED = "om.reflections.recorded";
 export const OM_OBSERVATIONS_DROPPED = "om.observations.dropped";
 export const OM_FOLDED = "om.folded";
@@ -53,6 +58,10 @@ export type ObservationsDroppedEntryData = {
 	coversUpToId: string;
 };
 
+export type ObservationsNoneEntryData = {
+	coversUpToId: string;
+};
+
 export type MemoryDetails = {
 	type: typeof OM_FOLDED;
 	version: 1;
@@ -63,6 +72,7 @@ export type MemoryDetails = {
 
 export type V3MemoryCustomType =
 	| typeof OM_OBSERVATIONS_RECORDED
+	| typeof OM_OBSERVATIONS_NONE
 	| typeof OM_REFLECTIONS_RECORDED
 	| typeof OM_OBSERVATIONS_DROPPED;
 
@@ -138,6 +148,11 @@ export function isObservationsDroppedData(value: unknown): value is Observations
 	return isNonEmptyStringArray(value.observationIds) && isNonEmptyString(value.coversUpToId);
 }
 
+export function isObservationsNoneData(value: unknown): value is ObservationsNoneEntryData {
+	if (!isPlainRecord(value)) return false;
+	return isNonEmptyString(value.coversUpToId);
+}
+
 export function isMemoryDetails(value: unknown): value is MemoryDetails {
 	if (!isPlainRecord(value)) return false;
 	return (
@@ -175,6 +190,14 @@ export function isObservationsDroppedEntry(entry: Entry): entry is Entry & {
 	return entry.type === "custom" && entry.customType === OM_OBSERVATIONS_DROPPED && isObservationsDroppedData(entry.data);
 }
 
+export function isObservationsNoneEntry(entry: Entry): entry is Entry & {
+	type: "custom";
+	customType: typeof OM_OBSERVATIONS_NONE;
+	data: ObservationsNoneEntryData;
+} {
+	return entry.type === "custom" && entry.customType === OM_OBSERVATIONS_NONE && isObservationsNoneData(entry.data);
+}
+
 export function buildObservationsRecordedData(
 	observations: Observation[],
 	coversUpToId: string,
@@ -197,4 +220,11 @@ export function buildObservationsDroppedData(
 ): ObservationsDroppedEntryData | undefined {
 	if (observationIds.length === 0 || !isNonEmptyString(coversUpToId)) return undefined;
 	return { observationIds, coversUpToId };
+}
+
+export function buildObservationsNoneData(
+	coversUpToId: string,
+): ObservationsNoneEntryData | undefined {
+	if (!isNonEmptyString(coversUpToId)) return undefined;
+	return { coversUpToId };
 }

--- a/tests/consolidation-trigger.test.ts
+++ b/tests/consolidation-trigger.test.ts
@@ -13,6 +13,7 @@ vi.mock("../src/agents/dropper/agent.js", () => ({ runDropper: mockAgents.runDro
 import { registerConsolidationTrigger } from "../src/hooks/consolidation-trigger.js";
 import {
 	OM_OBSERVATIONS_DROPPED,
+	OM_OBSERVATIONS_NONE,
 	OM_OBSERVATIONS_RECORDED,
 	OM_REFLECTIONS_RECORDED,
 } from "../src/session-ledger/index.js";
@@ -228,16 +229,24 @@ describe("V3 consolidation trigger", () => {
 		expect(pi.appendEntry).toHaveBeenCalledWith(OM_OBSERVATIONS_RECORDED, { observations: [newObs], coversUpToId: "raw-3" });
 	});
 
-	it("observer no-output appends nothing and does not fake observation coverage", async () => {
+	it("observer no-output records a coverage-only marker so the span is not re-observed", async () => {
 		const entries = [textCustomMessage("raw-1", "aaaaaaaa")];
-		const { fire, runLaunchedWork, pi } = setup({ entries });
+		const { fire, runLaunchedWork, pi, ctx } = setup({ entries });
 
 		fire();
 		await runLaunchedWork();
 
-		expect(pi.appendEntry).not.toHaveBeenCalled();
+		// Advances the observation coverage watermark without fabricating any
+		// observations, so the observer does not re-run on the same span every turn.
+		expect(pi.appendEntry).toHaveBeenCalledTimes(1);
+		expect(pi.appendEntry).toHaveBeenCalledWith(OM_OBSERVATIONS_NONE, { coversUpToId: "raw-1" });
+		expect(pi.appendEntry).not.toHaveBeenCalledWith(OM_OBSERVATIONS_RECORDED, expect.anything());
 		expect(mockAgents.runReflector).not.toHaveBeenCalled();
 		expect(mockAgents.runDropper).not.toHaveBeenCalled();
+		expect(ctx.ui.notify).toHaveBeenCalledWith(
+			"Observational memory: observer found nothing new to record",
+			"info",
+		);
 	});
 
 	it("model resolution failure skips appending and notifies once", async () => {

--- a/tests/fixtures/session.ts
+++ b/tests/fixtures/session.ts
@@ -30,6 +30,7 @@ export type TestReflection = {
 };
 
 export const V3_OBSERVATIONS_RECORDED = "om.observations.recorded";
+export const V3_OBSERVATIONS_NONE = "om.observations.none";
 export const V3_REFLECTIONS_RECORDED = "om.reflections.recorded";
 export const V3_OBSERVATIONS_DROPPED = "om.observations.dropped";
 export const V3_FOLDED = "om.folded";
@@ -196,6 +197,22 @@ export function observationsDroppedEntry(
 		parentId: null,
 		timestamp: DEFAULT_TIMESTAMP,
 		customType: V3_OBSERVATIONS_DROPPED,
+		data: args,
+		...overrides,
+	};
+}
+
+export function observationsNoneEntry(
+	id: string,
+	args: { coversUpToId: string },
+	overrides: Partial<TestEntry> = {},
+): TestEntry {
+	return {
+		type: "custom",
+		id,
+		parentId: null,
+		timestamp: DEFAULT_TIMESTAMP,
+		customType: V3_OBSERVATIONS_NONE,
 		data: args,
 		...overrides,
 	};

--- a/tests/session-ledger-progress.test.ts
+++ b/tests/session-ledger-progress.test.ts
@@ -14,12 +14,14 @@ import {
 } from "../src/session-ledger/index.js";
 import {
 	V3_OBSERVATIONS_DROPPED,
+	V3_OBSERVATIONS_NONE,
 	V3_OBSERVATIONS_RECORDED,
 	V3_REFLECTIONS_RECORDED,
 	branchSummary,
 	compactionEntry,
 	observation,
 	observationsDroppedEntry,
+	observationsNoneEntry,
 	observationsRecordedEntry,
 	oldV2ObservationEntry,
 	reflection,
@@ -139,5 +141,34 @@ describe("session-ledger V3 progress helpers", () => {
 		];
 
 		expect(rawTokensSinceLastCompaction(entries)).toBe(3); // raw-1 + raw-2 from live tail starting at firstKeptEntryId
+	});
+
+	it("advances observation coverage on a coverage-only 'none' marker (no recorded observations)", () => {
+		const entries = [
+			textCustomMessage("raw-1", "aaaa"),
+			textCustomMessage("raw-2", "bbbb"),
+			observationsNoneEntry("om-none", { coversUpToId: "raw-2" }),
+		];
+
+		// The 'none' marker alone moves the observation watermark, so an empty
+		// observer verdict does not leave the same span re-triggering every turn.
+		expect(rawTokensSinceObservationCoverage(entries)).toBe(0);
+		// ...even though there is no recorded-observations marker at all.
+		expect(latestCoverageMarkerId(entries, V3_OBSERVATIONS_RECORDED)).toBeUndefined();
+		// New source after the marker is still uncovered and will re-trigger normally.
+		entries.push(textCustomMessage("raw-3", "cccc"));
+		expect(rawTokensSinceObservationCoverage(entries)).toBeGreaterThan(0); // raw-3 only
+	});
+
+	it("keeps the 'none' marker out of reflection and drop coverage", () => {
+		const entries = [
+			textCustomMessage("raw-1", "aaaa"),
+			observationsNoneEntry("om-none", { coversUpToId: "raw-1" }),
+		];
+
+		// Reflection / drop watermarks track their own marker types only, so a
+		// 'none' observation marker must NOT advance them.
+		expect(rawTokensSinceReflectionCoverage(entries)).toBeGreaterThan(0);
+		expect(rawTokensSinceDropCoverage(entries)).toBeGreaterThan(0);
 	});
 });


### PR DESCRIPTION
Fixes #23


## Summary

When the observer returns **no** observations for a chunk, the observation
coverage watermark is never advanced, so the observer re-runs on **every**
subsequent turn over the same (growing) span — spamming
`Observational memory: observer returned no observations` and burning one
observer model call per turn — until some later turn happens to produce an
observation.

This PR adds a coverage-only ledger marker (`om.observations.none`) that the
observer writes on an empty result, so the watermark advances and the span is
not reprocessed. No observations are fabricated; no memory is lost.

## Problem (observed in the wild)

With `observational-memory.debugLog: true`, a single session showed the observer
firing 9 times: **5 of them empty, back-to-back**. The empty runs kept the chunk
**start pinned** while only the end grew, so token count climbed past the trigger
every turn:

```
21:00:52 START first=1ffebad0 last=bd84d836 n=34 tok=10286  -> EMPTY (warning)
21:01:21 START first=1ffebad0 last=c87a1d5b n=36 tok=10995  -> EMPTY (warning)
21:01:40 START first=1ffebad0 last=f284f95c n=38 tok=11894  -> EMPTY (warning)
21:01:56 START first=1ffebad0 last=a606b101 n=40 tok=12423  -> EMPTY (warning)
21:02:19 START first=1ffebad0 last=dab0235d n=42 tok=12932  -> EMPTY (warning)
21:02:30 START first=1ffebad0 last=74daaf4f n=43 tok=13306  -> records 8  (watermark finally advances)
```

Every `agent_start`/`turn_end` during that window re-ran the observer on the same
leading span and re-emitted the warning. It only recovered once enough new tail
accumulated that the observer incidentally found something to record.

## Root cause

`runObserverStage` (in `src/hooks/consolidation-trigger.ts`) gates on
`rawTokensSinceObservationCoverage(entries) >= observeAfterTokens`. On a
non-empty result it appends an `om.observations.recorded` marker, which advances
the watermark. The empty branch did not:

```ts
if (!observations || observations.length === 0) {
    debugLog("observer.empty", { coversUpToId });
    if (ctx.hasUI) ctx.ui?.notify("Observational memory: observer returned no observations", "warning");
    return "continue";          // <-- no coverage marker written
}
```

And `om.observations.recorded` is the **only** entry type that advances
observation coverage — `isValidCoverageEntry` (in `session-ledger/progress.ts`)
requires a non-empty `observations` array. So the empty verdict left the
watermark stuck and the chunk perpetually over-threshold.

## Fix

- New coverage-only marker `OM_OBSERVATIONS_NONE = "om.observations.none"` with
  data `{ coversUpToId }` (`session-ledger/types.ts`): builder
  `buildObservationsNoneData`, guard `isObservationsNoneEntry`, added to
  `V3MemoryCustomType`.
- Observation-coverage scans now consider **both** marker types via
  `OBSERVATION_COVERAGE_TYPES = [OM_OBSERVATIONS_RECORDED, OM_OBSERVATIONS_NONE]`.
  `latestCoverageIndex` / `latestCoverageMarkerId` accept one type or an array;
  `rawTokensSinceObservationCoverage` and the observer chunk-start index use the
  array.
- The empty observer branch appends an `om.observations.none` marker for the
  chunk it just processed, then returns.
- The per-empty notification is downgraded from `warning`
  (`observer returned no observations`) to `info`
  (`observer found nothing new to record`), since with the watermark advancing
  this is a normal one-shot event, not a recurring error.

The marker carries no observations, so `projection`, `fold`, the reflector and
the dropper ignore it (they key off the typed `isObservations*Entry` guards).
**Reflection and drop watermarks are intentionally unchanged** — they still
track only their own marker types. Raw entries remain available to the reflector
and until compaction, so nothing is lost; the observer simply respects its own
"nothing to record here" verdict instead of repeating it every turn.

## Alternatives considered

- **Relax `om.observations.recorded` to allow an empty `observations` array.**
  Rejected: it would make the "valid coverage" and "has observations" predicates
  disagree for the same entry type, and an `observations.recorded` entry that
  records nothing is misleading. A dedicated marker is clearer and keeps the
  projection/fold guards untouched.
- **Just raise `observeAfterTokens`.** Only reduces frequency; the re-fire loop
  still occurs on any genuinely low-salience span.

## Backward compatibility

Additive. Old ledgers without `om.observations.none` markers behave exactly as
before. Unknown custom types are already ignored by `fold`/`projection`/`view`
(no exhaustive `customType` switch), so a downgrade after this lands degrades
gracefully (an `om.observations.none` entry is simply skipped, reverting to the
prior — buggy — behavior for that one span).

## Testing

- `npm run typecheck` — clean.
- `npm test` — **181 passing** (179 prior + 2 new).
- Updated `tests/consolidation-trigger.test.ts`: the no-output case now asserts a
  single `om.observations.none { coversUpToId }` marker is appended (and no
  `om.observations.recorded`), reflector/dropper are not called, and the
  notification is `info`.
- Added `tests/session-ledger-progress.test.ts`: a `none` marker advances
  observation coverage even with no recorded marker present, new source after it
  is still uncovered, and it does **not** advance reflection/drop coverage.
- Added an `observationsNoneEntry` fixture + `V3_OBSERVATIONS_NONE` constant.
