### PR TITLE
feat: add ratio mode for context-window-scaled compaction threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,8 @@ A typical config:
     "observeAfterTokens": 10000,
     "reflectAfterTokens": 20000,
     "compactAfterTokens": 81000,
+    "compactAfterTokensMode": "calibrated",
+    "compactAfterTokensRatio": 0.68,
     "observationsPoolMaxTokens": 20000,
     "observationsPoolTargetTokens": 10000,
     "agentMaxTurns": 16,
@@ -224,13 +226,52 @@ A typical config:
 
 Most users can start with the defaults and tune only if they have a specific reason.
 
+### Scaling compaction to the model's context window
+
+By default `compactAfterTokensMode` is `"calibrated"`, so the proactive
+compaction trigger fires at the fixed `compactAfterTokens` value (81,000 by
+default). That is backwards-compatible and works well for typical ~128K–200K
+context models.
+
+On a large-context model (e.g. 1M tokens) the calibrated default preempts
+compaction at ~81K, wasting most of the window. Switch to `"ratio"` mode to let
+the trigger scale with the active model's `contextWindow`:
+
+```json
+{
+  "observational-memory": {
+    "compactAfterTokens": 81000,
+    "compactAfterTokensMode": "ratio",
+    "compactAfterTokensRatio": 0.5
+  }
+}
+```
+
+In ratio mode the effective threshold is
+`floor(model.contextWindow * compactAfterTokensRatio)` (clamped to a minimum of
+1). With the example above, a 1,000,000-token window compacts at ~500,000 raw
+tokens; a 200,000-token window compacts at ~100,000.
+
+`compactAfterTokensRatio` is user-tunable precisely because **context window ≠
+attention**. Some models advertise a large window but degrade at long range; set
+a lower ratio (e.g. `0.4`) to compact earlier on those, or a higher ratio
+(e.g. `0.7`) on models that stay sharp. The default ratio is `0.68`.
+
+`compactAfterTokens` is always retained as the fallback: in `"calibrated"`
+mode it is the threshold directly, and in `"ratio"` mode it is used whenever
+the active model's `contextWindow` is unavailable (undefined, 0, or negative),
+so compaction still triggers safely. `/om:status` shows the resolved threshold
+on the `Next compaction` line regardless of mode.
+
 ### Defaults
 
 | Setting                     | Default       | Meaning                                                                                           |
 | --------------------------- | ------------- | ------------------------------------------------------------------------------------------------- |
 | `observeAfterTokens`        | `10000`       | Raw/source token threshold for observation runs.                                                  |
 | `reflectAfterTokens`        | `20000`       | Raw/source token threshold for reflection runs; successful reflection creates dropper opportunities. |
-| `compactAfterTokens`        | `81000`       | Raw/source token threshold for proactive auto-compaction.                                         |
+| `compactAfterTokens`        | `81000`       | Raw/source token threshold for proactive auto-compaction (used directly in `"calibrated"` mode, and as the fallback in `"ratio"` mode). |
+| `compactAfterTokensMode`    | `"calibrated"`| `"calibrated"` uses `compactAfterTokens` directly (default, backwards-compatible). `"ratio"` scales the threshold by the active model's `contextWindow`. |
+| `compactAfterTokensRatio`   | `0.68`        | In `"ratio"` mode, the threshold is `floor(contextWindow * ratio)`. Tunable because large windows do not always mean strong long-range attention. Must be in `(0, 1)`. |
 | `observationsPoolMaxTokens` | `20000`       | Observation-token budget used for compaction full-fold pressure.                                  |
 | `observationsPoolTargetTokens` | half of max | Active observation target used by post-reflection dropper maintenance.                            |
 | `agentMaxTurns`             | `16`          | Shared turn cap for background memory-agent loops.                                                |

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -1,5 +1,6 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { observationPoolMetrics } from "../agents/dropper/pool.js";
+import { resolveCompactAfterTokens } from "../config.js";
 import type { Runtime } from "../runtime.js";
 import {
 	diffProjection,
@@ -61,6 +62,8 @@ export function registerStatusCommand(pi: ExtensionAPI, runtime: Runtime): void 
 			const obsProgress = rawTokensSinceObservationCoverage(entries);
 			const reflectionProgress = rawTokensSinceReflectionCoverage(entries);
 			const compactionProgress = rawTokensSinceLastCompaction(entries);
+			const contextWindow = typeof ctx.model?.contextWindow === "number" ? ctx.model.contextWindow : undefined;
+			const compactThreshold = resolveCompactAfterTokens(runtime.config, contextWindow);
 
 			const passiveLines = runtime.config.passive === true
 				? [
@@ -79,7 +82,7 @@ export function registerStatusCommand(pi: ExtensionAPI, runtime: Runtime): void 
 				"── Activity ──",
 				`Next observation: ~${obsProgress.toLocaleString()} / ${runtime.config.observeAfterTokens.toLocaleString()} tokens (${pct(obsProgress, runtime.config.observeAfterTokens)}%)`,
 				`Next reflection:  ~${reflectionProgress.toLocaleString()} / ${runtime.config.reflectAfterTokens.toLocaleString()} tokens (${pct(reflectionProgress, runtime.config.reflectAfterTokens)}%)`,
-				`Next compaction:  ~${compactionProgress.toLocaleString()} / ${runtime.config.compactAfterTokens.toLocaleString()} tokens (${pct(compactionProgress, runtime.config.compactAfterTokens)}%)`,
+				`Next compaction:  ~${compactionProgress.toLocaleString()} / ${compactThreshold.toLocaleString()} tokens (${pct(compactionProgress, compactThreshold)}%)`,
 				`Visible observation pool: ~${visibleObservationTokens.toLocaleString()} / ${runtime.config.observationsPoolMaxTokens.toLocaleString()} tokens (${pct(visibleObservationTokens, runtime.config.observationsPoolMaxTokens)}%)`,
 				`Active observation pool: ~${activeObservationPool.observationTokens.toLocaleString()} / ${runtime.config.observationsPoolTargetTokens.toLocaleString()} target tokens (${pct(activeObservationPool.observationTokens, runtime.config.observationsPoolTargetTokens)}%)`,
 				`Reflection pool:         ~${visibleReflectionTokens.toLocaleString()} tokens`,

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,10 +9,33 @@ export interface ConfiguredModel {
 	thinking?: ModelThinkingLevel;
 }
 
+/**
+ * How `compactAfterTokens` is interpreted.
+ *
+ * - `"calibrated"` (default): use the static `compactAfterTokens` value directly.
+ *   Backwards-compatible with all existing V3 configs.
+ *
+ * - `"ratio"`: compute the effective threshold as
+ *   `floor(model.contextWindow * compactAfterTokensRatio)`. This auto-scales the
+ *   proactive compaction trigger to the active model's context window, so a 1M
+ *   context model is not preempted at the same 81K threshold as a 128K model.
+ *
+ *   Some models advertise a large context window but lose attention at long
+ *   range; users can lower `compactAfterTokensRatio` to compact earlier on such
+ *   models without giving up the window on models that stay sharp.
+ *
+ *   When the active model's `contextWindow` is unavailable (undefined, 0, or
+ *   negative), ratio mode falls back to the calibrated `compactAfterTokens`
+ *   value so compaction still triggers safely.
+ */
+export type CompactAfterTokensMode = "calibrated" | "ratio";
+
 export interface Config {
 	observeAfterTokens: number;
 	reflectAfterTokens: number;
 	compactAfterTokens: number;
+	compactAfterTokensMode: CompactAfterTokensMode;
+	compactAfterTokensRatio: number;
 	observationsPoolMaxTokens: number;
 	observationsPoolTargetTokens: number;
 	agentMaxTurns: number;
@@ -25,12 +48,33 @@ export const DEFAULTS: Config = {
 	observeAfterTokens: 10_000,
 	reflectAfterTokens: 20_000,
 	compactAfterTokens: 81_000,
+	compactAfterTokensMode: "calibrated",
+	compactAfterTokensRatio: 0.68,
 	observationsPoolMaxTokens: 20_000,
 	observationsPoolTargetTokens: 10_000,
 	agentMaxTurns: 16,
 	passive: false,
 	debugLog: false,
 };
+
+export const COMPACT_AFTER_TOKENS_MODE_VALUES: readonly CompactAfterTokensMode[] = ["calibrated", "ratio"] as const;
+
+/**
+ * Resolve the effective proactive-compaction token threshold for the given
+ * config and active model context window.
+ *
+ * In `"calibrated"` mode this is always `config.compactAfterTokens`.
+ *
+ * In `"ratio"` mode this is `floor(contextWindow * compactAfterTokensRatio)`
+ * (clamped to a minimum of 1) when `contextWindow` is a positive number, and
+ * falls back to `config.compactAfterTokens` otherwise.
+ */
+export function resolveCompactAfterTokens(config: Config, contextWindow: number | undefined): number {
+	if (config.compactAfterTokensMode === "ratio" && typeof contextWindow === "number" && contextWindow > 0) {
+		return Math.max(1, Math.floor(contextWindow * config.compactAfterTokensRatio));
+	}
+	return config.compactAfterTokens;
+}
 
 export const THINKING_LEVEL_VALUES: readonly ModelThinkingLevel[] = ["off", "minimal", "low", "medium", "high", "xhigh"] as const;
 
@@ -52,6 +96,19 @@ function derivedObservationPoolTarget(maxTokens: number): number {
 
 function isThinkingLevel(value: unknown): value is ModelThinkingLevel {
 	return typeof value === "string" && (THINKING_LEVEL_VALUES as readonly string[]).includes(value);
+}
+
+function isCompactAfterTokensMode(value: unknown): value is CompactAfterTokensMode {
+	return typeof value === "string" && (COMPACT_AFTER_TOKENS_MODE_VALUES as readonly string[]).includes(value);
+}
+
+/**
+ * A valid ratio is a finite number strictly between 0 and 1.
+ * 0 would never trigger; >= 1 would compact at/after the full window with no
+ * room left for the response.
+ */
+function validRatioOrUndefined(value: unknown): number | undefined {
+	return typeof value === "number" && Number.isFinite(value) && value > 0 && value < 1 ? value : undefined;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -86,6 +143,11 @@ function normalizeSettingsConfig(value: Record<string, unknown>): Partial<Config
 		const normalizedValue = positiveIntegerOrUndefined(value[key]);
 		if (normalizedValue !== undefined) normalized[key] = normalizedValue;
 	}
+	if (isCompactAfterTokensMode(value.compactAfterTokensMode)) {
+		normalized.compactAfterTokensMode = value.compactAfterTokensMode;
+	}
+	const ratio = validRatioOrUndefined(value.compactAfterTokensRatio);
+	if (ratio !== undefined) normalized.compactAfterTokensRatio = ratio;
 	if (typeof value.passive === "boolean") normalized.passive = value.passive;
 	if (typeof value.debugLog === "boolean") normalized.debugLog = value.debugLog;
 	const model = normalizeModel(value.model);

--- a/src/hooks/compaction-trigger.ts
+++ b/src/hooks/compaction-trigger.ts
@@ -1,4 +1,5 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { resolveCompactAfterTokens } from "../config.js";
 import { rawTokensSinceLastCompaction, type Entry } from "../session-ledger/index.js";
 import type { Runtime } from "../runtime.js";
 
@@ -33,7 +34,12 @@ export function registerCompactionTrigger(pi: ExtensionAPI, runtime: Runtime): v
 
 		const entries = ctx.sessionManager.getBranch() as Entry[];
 		const tokens = rawTokensSinceLastCompaction(entries);
-		if (tokens < runtime.config.compactAfterTokens) return;
+		// Resolve the proactive-compaction threshold from the active model's context
+		// window when ratio mode is configured. ctx.model is the current session model
+		// (Model<any> | undefined per ExtensionContext).
+		const contextWindow = typeof ctx.model?.contextWindow === "number" ? ctx.model.contextWindow : undefined;
+		const threshold = resolveCompactAfterTokens(runtime.config, contextWindow);
+		if (tokens < threshold) return;
 
 		// Capture ctx properties synchronously — the setTimeout + async work below
 		// may outlive the extension ctx (stale after session replacement/reload).
@@ -58,7 +64,7 @@ export function registerCompactionTrigger(pi: ExtensionAPI, runtime: Runtime): v
 				}
 				const currentEntries = ctx.sessionManager.getBranch() as Entry[];
 				const currentTokens = rawTokensSinceLastCompaction(currentEntries);
-				if (currentTokens < runtime.config.compactAfterTokens) {
+				if (currentTokens < threshold) {
 					runtime.compactInFlight = false;
 					if (hasUI) ui?.notify(
 						"Observational memory: compaction skipped — another compaction already ran before deferred compaction",

--- a/tests/compaction-trigger.test.ts
+++ b/tests/compaction-trigger.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { registerCompactionTrigger } from "../src/hooks/compaction-trigger.js";
 import { compactionEntry, textCustomMessage, type TestEntry } from "./fixtures/session.js";
 
-function captureHandler(args: { compactAfterTokens?: number; passive?: boolean; compactInFlight?: boolean } = {}) {
+function captureHandler(args: { compactAfterTokens?: number; compactAfterTokensMode?: "calibrated" | "ratio"; compactAfterTokensRatio?: number; passive?: boolean; compactInFlight?: boolean } = {}) {
 	let handler: ((event: unknown, ctx: unknown) => void) | undefined;
 	const pi = {
 		on: vi.fn((name: string, cb: typeof handler) => {
@@ -15,6 +15,8 @@ function captureHandler(args: { compactAfterTokens?: number; passive?: boolean; 
 		ensureConfig: vi.fn(),
 		config: {
 			compactAfterTokens: args.compactAfterTokens ?? 3,
+			compactAfterTokensMode: args.compactAfterTokensMode ?? "calibrated",
+			compactAfterTokensRatio: args.compactAfterTokensRatio ?? 0.68,
 			passive: args.passive ?? false,
 		},
 		compactInFlight: args.compactInFlight ?? false,
@@ -48,6 +50,7 @@ function fakeCtx(branches: TestEntry[][], overrides: Record<string, unknown> = {
 		ui: { notify: vi.fn() },
 		isIdle: vi.fn(() => true),
 		compact: vi.fn(),
+		model: undefined,
 		...overrides,
 	};
 }
@@ -179,5 +182,86 @@ describe("V3 compaction trigger", () => {
 		await vi.runAllTimersAsync();
 
 		expect(ctx.compact).toHaveBeenCalledTimes(1);
+	});
+
+	describe("ratio mode", () => {
+		it("scales the compaction threshold by model.contextWindow", async () => {
+			// 3 tokens raw; ratio 0.5 of 4-token window = 2 -> threshold 2, so 3 >= 2 fires.
+			const { handler } = captureHandler({
+				compactAfterTokens: 81000,
+				compactAfterTokensMode: "ratio",
+				compactAfterTokensRatio: 0.5,
+			});
+			const ctx = fakeCtx([dueBranch], { model: { contextWindow: 4 } });
+
+			handler(agentEnd(), ctx);
+			await vi.runAllTimersAsync();
+
+			expect(ctx.compact).toHaveBeenCalledTimes(1);
+		});
+
+		it("does not compact when raw tokens are below the scaled threshold", async () => {
+			// 1 token raw (belowBranch); ratio 0.5 of 4 = 2 -> threshold 2, so 1 < 2 does not fire.
+			const { handler } = captureHandler({
+				compactAfterTokens: 81000,
+				compactAfterTokensMode: "ratio",
+				compactAfterTokensRatio: 0.5,
+			});
+			const ctx = fakeCtx([belowBranch], { model: { contextWindow: 4 } });
+
+			handler(agentEnd(), ctx);
+			await vi.runAllTimersAsync();
+
+			expect(ctx.compact).not.toHaveBeenCalled();
+		});
+
+		it("falls back to calibrated value when model.contextWindow is unavailable", async () => {
+			// ratio mode but no model -> falls back to compactAfterTokens=81000, so 3 tokens won't fire.
+			const { handler } = captureHandler({
+				compactAfterTokens: 81000,
+				compactAfterTokensMode: "ratio",
+				compactAfterTokensRatio: 0.5,
+			});
+			const ctx = fakeCtx([dueBranch], { model: undefined });
+
+			handler(agentEnd(), ctx);
+			await vi.runAllTimersAsync();
+
+			expect(ctx.compact).not.toHaveBeenCalled();
+		});
+
+		it("falls back to calibrated value when contextWindow is zero", async () => {
+			const { handler } = captureHandler({
+				compactAfterTokens: 81000,
+				compactAfterTokensMode: "ratio",
+				compactAfterTokensRatio: 0.5,
+			});
+			const ctx = fakeCtx([dueBranch], { model: { contextWindow: 0 } });
+
+			handler(agentEnd(), ctx);
+			await vi.runAllTimersAsync();
+
+			expect(ctx.compact).not.toHaveBeenCalled();
+		});
+
+		it("uses the same resolved threshold on deferred re-check", async () => {
+			// threshold = 0.5 * 4 = 2; first branch has 3 (fires, deferred), isIdle=false defers,
+			// second branch has 1 (< 2) -> skipped because another compaction reduced pressure.
+			const { handler, runtime } = captureHandler({
+				compactAfterTokens: 81000,
+				compactAfterTokensMode: "ratio",
+				compactAfterTokensRatio: 0.5,
+			});
+			const ctx = fakeCtx([dueBranch, belowBranch], {
+				model: { contextWindow: 4 },
+				isIdle: vi.fn(() => false),
+			});
+
+			handler(agentEnd(), ctx);
+			await vi.runAllTimersAsync();
+
+			expect(ctx.compact).not.toHaveBeenCalled();
+			expect(runtime.compactInFlight).toBe(false);
+		});
 	});
 });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -9,7 +9,7 @@ vi.mock("@earendil-works/pi-coding-agent", () => ({
 	getAgentDir: () => mock.agentDir,
 }));
 
-import { DEFAULTS, loadConfig, readEnvConfig } from "../src/config.js";
+import { DEFAULTS, loadConfig, readEnvConfig, resolveCompactAfterTokens } from "../src/config.js";
 
 function writeJson(path: string, value: unknown) {
 	mkdirSync(join(path, ".."), { recursive: true });
@@ -39,6 +39,8 @@ describe("V3 config", () => {
 			observeAfterTokens: 10000,
 			reflectAfterTokens: 20000,
 			compactAfterTokens: 81000,
+			compactAfterTokensMode: "calibrated",
+			compactAfterTokensRatio: 0.68,
 			observationsPoolMaxTokens: 20000,
 			observationsPoolTargetTokens: 10000,
 			agentMaxTurns: 16,
@@ -154,5 +156,102 @@ describe("V3 config", () => {
 		expect(readEnvConfig({ PI_OBSERVATIONAL_MEMORY_PASSIVE: "on" })).toEqual({ passive: true });
 		expect(readEnvConfig({ PI_OBSERVATIONAL_MEMORY_PASSIVE: "0" })).toEqual({ passive: false });
 		expect(readEnvConfig({ PI_OBSERVATIONAL_MEMORY_PASSIVE: "maybe" })).toEqual({});
+	});
+
+	describe("compactAfterTokens ratio mode", () => {
+		it("accepts compactAfterTokensMode and compactAfterTokensRatio", () => {
+			writeJson(join(cwd, ".pi", "settings.json"), {
+				"observational-memory": {
+					compactAfterTokensMode: "ratio",
+					compactAfterTokensRatio: 0.5,
+				},
+			});
+
+			expect(loadConfig(cwd, {})).toMatchObject({
+				compactAfterTokensMode: "ratio",
+				compactAfterTokensRatio: 0.5,
+			});
+		});
+
+		it("rejects invalid mode values and falls back to default calibrated", () => {
+			writeJson(join(cwd, ".pi", "settings.json"), {
+				"observational-memory": {
+					compactAfterTokensMode: "auto",
+				},
+			});
+
+			expect(loadConfig(cwd, {})).toMatchObject({ compactAfterTokensMode: "calibrated" });
+		});
+
+		it("rejects ratio outside (0, 1) and falls back to default", () => {
+			writeJson(join(cwd, ".pi", "settings.json"), {
+				"observational-memory": {
+					compactAfterTokensRatio: 0,
+				},
+			});
+			expect(loadConfig(cwd, {})).toMatchObject({ compactAfterTokensRatio: 0.68 });
+
+			writeJson(join(cwd, ".pi", "settings.json"), {
+				"observational-memory": {
+					compactAfterTokensRatio: 1,
+				},
+			});
+			expect(loadConfig(cwd, {})).toMatchObject({ compactAfterTokensRatio: 0.68 });
+
+			writeJson(join(cwd, ".pi", "settings.json"), {
+				"observational-memory": {
+					compactAfterTokensRatio: 1.5,
+				},
+			});
+			expect(loadConfig(cwd, {})).toMatchObject({ compactAfterTokensRatio: 0.68 });
+
+			writeJson(join(cwd, ".pi", "settings.json"), {
+				"observational-memory": {
+					compactAfterTokensRatio: -0.2,
+				},
+			});
+			expect(loadConfig(cwd, {})).toMatchObject({ compactAfterTokensRatio: 0.68 });
+		});
+
+		it("rejects non-numeric ratio and falls back to default", () => {
+			writeJson(join(cwd, ".pi", "settings.json"), {
+				"observational-memory": {
+					compactAfterTokensRatio: "0.5",
+				},
+			});
+			expect(loadConfig(cwd, {})).toMatchObject({ compactAfterTokensRatio: 0.68 });
+		});
+	});
+
+	describe("resolveCompactAfterTokens", () => {
+		it("returns the calibrated value in calibrated mode", () => {
+			const config = { ...DEFAULTS, compactAfterTokensMode: "calibrated", compactAfterTokens: 81000 } as any;
+			expect(resolveCompactAfterTokens(config, 1_000_000)).toBe(81000);
+		});
+
+		it("returns calibrated value regardless of context window in calibrated mode", () => {
+			const config = { ...DEFAULTS, compactAfterTokensMode: "calibrated", compactAfterTokens: 81000 } as any;
+			expect(resolveCompactAfterTokens(config, undefined)).toBe(81000);
+			expect(resolveCompactAfterTokens(config, 0)).toBe(81000);
+		});
+
+		it("scales by context window in ratio mode", () => {
+			const config = { ...DEFAULTS, compactAfterTokensMode: "ratio", compactAfterTokensRatio: 0.5, compactAfterTokens: 81000 } as any;
+			expect(resolveCompactAfterTokens(config, 1_000_000)).toBe(500_000);
+			expect(resolveCompactAfterTokens(config, 200_000)).toBe(100_000);
+		});
+
+		it("floors fractional results to an integer >= 1", () => {
+			const config = { ...DEFAULTS, compactAfterTokensMode: "ratio", compactAfterTokensRatio: 0.5, compactAfterTokens: 81000 } as any;
+			expect(resolveCompactAfterTokens(config, 3)).toBe(1);
+			expect(resolveCompactAfterTokens(config, 1)).toBe(1);
+		});
+
+		it("falls back to calibrated value when context window is unavailable in ratio mode", () => {
+			const config = { ...DEFAULTS, compactAfterTokensMode: "ratio", compactAfterTokensRatio: 0.5, compactAfterTokens: 81000 } as any;
+			expect(resolveCompactAfterTokens(config, undefined)).toBe(81000);
+			expect(resolveCompactAfterTokens(config, 0)).toBe(81000);
+			expect(resolveCompactAfterTokens(config, -1)).toBe(81000);
+		});
 	});
 });

--- a/tests/status-command.test.ts
+++ b/tests/status-command.test.ts
@@ -15,7 +15,7 @@ import {
 	type TestEntry,
 } from "./fixtures/session.js";
 
-function setup(args: { entries: TestEntry[]; runtime?: Partial<any> }) {
+function setup(args: { entries: TestEntry[]; runtime?: Partial<any>; model?: unknown }) {
 	let handler: ((args: unknown, ctx: any) => Promise<void>) | undefined;
 	const pi = {
 		registerCommand: vi.fn((name: string, command: { handler: typeof handler }) => {
@@ -45,7 +45,7 @@ function setup(args: { entries: TestEntry[]; runtime?: Partial<any> }) {
 	registerStatusCommand(pi as any, runtime as any);
 	if (!handler) throw new Error("status handler not registered");
 	const notify = vi.fn();
-	const ctx = { cwd: "/tmp/project", ui: { notify }, sessionManager: { getBranch: () => args.entries } };
+	const ctx = { cwd: "/tmp/project", ui: { notify }, sessionManager: { getBranch: () => args.entries }, model: args.model };
 	const run = async () => {
 		await handler!(undefined, ctx);
 		return notify.mock.calls.at(-1)?.[0] as string;
@@ -165,5 +165,70 @@ describe("V3 /om:status", () => {
 
 		expect(output).toContain("Consolidation: running");
 		expect(output).not.toContain("Consolidation: running (");
+	});
+
+	describe("ratio mode", () => {
+		it("shows the context-window-scaled threshold in the Next compaction line", async () => {
+			const output = await setup({
+				entries: [],
+				runtime: {
+					config: {
+						observeAfterTokens: 10,
+						reflectAfterTokens: 20,
+						compactAfterTokens: 30,
+						compactAfterTokensMode: "ratio",
+						compactAfterTokensRatio: 0.5,
+						observationsPoolMaxTokens: 40,
+						observationsPoolTargetTokens: 20,
+						passive: false,
+					},
+				},
+				model: { contextWindow: 1_000_000 },
+			}).run();
+
+			expect(output).toContain("Next compaction:  ~0 / 500,000 tokens (0%)");
+		});
+
+		it("falls back to calibrated threshold when model is unavailable in ratio mode", async () => {
+			const output = await setup({
+				entries: [],
+				runtime: {
+					config: {
+						observeAfterTokens: 10,
+						reflectAfterTokens: 20,
+						compactAfterTokens: 30,
+						compactAfterTokensMode: "ratio",
+						compactAfterTokensRatio: 0.5,
+						observationsPoolMaxTokens: 40,
+						observationsPoolTargetTokens: 20,
+						passive: false,
+					},
+				},
+				model: undefined,
+			}).run();
+
+			expect(output).toContain("Next compaction:  ~0 / 30 tokens (0%)");
+		});
+
+		it("falls back to calibrated threshold when contextWindow is zero in ratio mode", async () => {
+			const output = await setup({
+				entries: [],
+				runtime: {
+					config: {
+						observeAfterTokens: 10,
+						reflectAfterTokens: 20,
+						compactAfterTokens: 30,
+						compactAfterTokensMode: "ratio",
+						compactAfterTokensRatio: 0.5,
+						observationsPoolMaxTokens: 40,
+						observationsPoolTargetTokens: 20,
+						passive: false,
+					},
+				},
+				model: { contextWindow: 0 },
+			}).run();
+
+			expect(output).toContain("Next compaction:  ~0 / 30 tokens (0%)");
+		});
 	});
 });


### PR DESCRIPTION
## Summary

`compactAfterTokens` is a **static, model-agnostic** threshold (default 81,000). On a large-context model (e.g. a 1M-token window) this preempts proactive compaction at ~8% of the usable window — repeatedly discarding the KV-cache prefix the model just paid to build, and forcing re-computation of the entire tail on every compaction. The larger the window, the more cache each compaction throws away, yet the threshold never scales.

The pain is worse when **switching between multiple models**: a single hard-coded `compactAfterTokens` cannot be correct across 128K, 200K, and 1M windows at once. Tuned large it over-compacts the small windows; tuned small it wastes the large ones. Users are forced to maintain a separate settings file per model, or to hand-edit the threshold on every switch.

This PR adds a `compactAfterTokensMode` switch (`"calibrated"` | `"ratio"`) and a user-tunable `compactAfterTokensRatio` (default 0.68) so the proactive compaction trigger can scale with the active model's `contextWindow`. The default `"calibrated"` mode is fully backwards-compatible; `"ratio"` mode computes `floor(contextWindow × ratio)` and falls back to the calibrated value when `contextWindow` is unavailable. `/om:status` now shows the resolved threshold regardless of mode. One config now covers every model.

## Problem (observed in the wild)

A 1M-context model session with the default config showed the compaction line pinned at 81K:

```
Next compaction:  ~X / 81,000 tokens (Y%)
```

The model has ~900K+ tokens of headroom, but compaction fires at the same 81K as a 128K model. Each firing rewrites the conversation history into a summary, invalidating the prompt-cache prefix from the rewrite point onward. On a large window this is doubly wasteful: the cache that gets discarded is larger, and the compaction itself was premature.

And when the user switches between models (say a 128K model locally and a 1M model remotely), a single static value cannot cover them all — a value tuned for 1M over-compacts 128K, and a value tuned for 128K is too aggressive for 1M. The user is left maintaining per-model settings or hand-editing the threshold on every switch.

Pi core already scales its own compaction off `model.contextWindow` (`shouldCompact(contextTokens, contextWindow, settings)`), but this extension does not — it hard-codes the threshold and ignores `contextWindow` entirely (zero references in `src/`).

## Root cause

`registerCompactionTrigger` (in `src/hooks/compaction-trigger.ts`) gates on:

```ts
if (tokens < runtime.config.compactAfterTokens) return;
```

`runtime.config.compactAfterTokens` is a plain number loaded from settings with no awareness of the active model. The `Config` type and `DEFAULTS` have no `contextWindow` field, and the `agent_end` handler — whose `ctx` carries `ctx.model` (with `contextWindow`) — never reads it. So a 1M model and a 128K model hit the same 81K trigger.

## Fix

- New config fields in `src/config.ts`:
  - `compactAfterTokensMode: "calibrated" | "ratio"` (default `"calibrated"`, backwards-compatible)
  - `compactAfterTokensRatio: number` (default `0.68`, validated to be a finite number in `(0, 1)`)
- New resolver `resolveCompactAfterTokens(config, contextWindow)`:
  - `"calibrated"` → always returns `config.compactAfterTokens`
  - `"ratio"` → `max(1, floor(contextWindow × ratio))` when `contextWindow` is a positive number; otherwise falls back to `config.compactAfterTokens`
- `registerCompactionTrigger` now reads `ctx.model?.contextWindow` and resolves the threshold via the helper. The resolved threshold is captured once and reused on the deferred re-check, so the immediate gate and the post-idle re-evaluation agree.
- `/om:status` resolves the same threshold from `ctx.model` and renders it on the `Next compaction` line, so the displayed denominator matches what actually triggers (instead of always showing the raw `compactAfterTokens`).

`compactAfterTokens` is retained in both modes: it is the threshold directly in `"calibrated"` mode, and the safe fallback in `"ratio"` mode whenever `contextWindow` is unavailable (undefined, 0, negative, or non-number — e.g. a custom provider that doesn't populate model metadata). No existing config breaks; the two new fields default to values that reproduce prior behavior exactly.

## Alternatives considered

- **Just raise the default `compactAfterTokens`.** Rejected: a single static value cannot be correct across 128K, 200K, and 1M windows. Raising it to suit 1M would over-compact 128K models; leaving it at 81K under-uses large windows. The threshold must scale with the window. This also **does not solve multi-model switching** — when the user moves between models of different window sizes, there is still no single config that works for all of them.
- **Auto-derive the ratio from `contextWindow` with no user control.** Rejected: context window ≠ long-range attention. Some models advertise a large window but degrade at long context; users need to lower the ratio for those. A fixed internal multiplier would forbid that.
- **Also scale `observeAfterTokens` / `reflectAfterTokens` by ratio.** Deliberately not done. Those two gate *background worker cadence*, not history rewriting — they do not touch the main conversation and do not invalidate KV-cache. Their relationship to window size is indirect (mediated by observation-pool pressure), so auto-scaling them would be over-fitting. Users can still tune them manually; `/om:status` surfaces pool pressure to inform that.

## Backward compatibility

Additive. Old configs without the two new fields load as `"calibrated"` mode with ratio `0.68`, and `resolveCompactAfterTokens` returns `compactAfterTokens` unchanged — byte-for-byte identical behavior to before. The `Config` type gains two required fields, but `DEFAULTS` populates them, so `loadConfig` always returns a complete object. A downgrade after this lands simply ignores the two fields and reverts to static-threshold behavior.

## Why a user-tunable ratio

Large context window does not imply strong long-range attention. A model may advertise 1M tokens but start losing fidelity well before that. The ratio is user-adjustable precisely so a user who knows their model's attention curve can compact earlier (lower ratio, e.g. 0.4) on degrading models, or later (higher ratio, e.g. 0.7) on models that stay sharp — without giving up the auto-scaling on models where the full window is trustworthy. The default 0.68 roughly reproduces the prior 81K/128K calibration while scaling linearly to other windows.

## Testing

- `npm run typecheck` — clean.
- `npm test` — **196 passing** (179 prior + 17 new).
- `tests/config.test.ts`: new defaults asserted; `compactAfterTokensMode` accepts only `"calibrated"` | `"ratio"` (invalid values fall back to default); `compactAfterTokensRatio` rejects 0, 1, ≥1, ≤0, and non-numbers; `resolveCompactAfterTokens` covers calibrated mode (ignores contextWindow), ratio mode (scales, floors, clamps to ≥1), and the three fallback cases (undefined / 0 / negative contextWindow).
- `tests/compaction-trigger.test.ts`: ratio mode fires when raw tokens ≥ `floor(contextWindow × ratio)`, does not fire below it, falls back to calibrated when `ctx.model` is undefined or `contextWindow` is 0, and the deferred re-check uses the same resolved threshold.
- `tests/status-command.test.ts`: `/om:status` renders the context-window-scaled threshold (e.g. `~0 / 500,000 tokens` for ratio 0.5 × 1M), and falls back to the calibrated value when the model is missing or `contextWindow` is 0.
