### PR TITLE
feat: make routine worker notifications optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ A typical config:
       "id": "google/gemma-4-31b-it",
       "thinking": "low"
     },
+    "showWorkerNotifications": true,
     "passive": false,
     "debugLog": false
   }
@@ -276,6 +277,7 @@ on the `Next compaction` line regardless of mode.
 | `observationsPoolTargetTokens` | half of max | Active observation target used by post-reflection dropper maintenance.                            |
 | `agentMaxTurns`             | `16`          | Shared turn cap for background memory-agent loops.                                                |
 | `model`                     | session model | Optional memory-worker model override: `{ provider, id, thinking }`.                              |
+| `showWorkerNotifications`   | `true`        | Shows routine observer, reflector, and dropper progress notifications. Warnings and errors are unaffected. |
 | `passive`                   | `false`       | Disables proactive background observation, reflection, maintenance, and auto-compaction triggers. |
 | `debugLog`                  | `false`       | Writes opt-in per-session extension debug events to Pi's agent directory.                         |
 
@@ -289,6 +291,8 @@ Valid `model.thinking` values are:
 * `xhigh`
 
 If no `model` is configured, memory workers use the session model.
+
+Set `showWorkerNotifications` to `false` to hide routine worker start and completion messages. Model fallback/unavailability, no-output warnings, worker failures, compaction notifications, and explicit `/om:*` command output remain visible.
 
 `observationsPoolMaxTokens` and `observationsPoolTargetTokens` intentionally describe different pools. Max tokens control when compaction performs a full fold over visible memory. Target tokens control the folded active observation pool that the dropper maintains after successful reflection. If the target is omitted, it defaults to half of max.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -40,6 +40,7 @@ The extension loads config once for its runtime. After changing settings, restar
       "id": "google/gemma-4-31b-it",
       "thinking": "low"
     },
+    "showWorkerNotifications": true,
     "passive": false,
     "debugLog": false
   }
@@ -62,6 +63,7 @@ You can omit everything. Defaults work for ordinary sessions, and if `model` is 
 | `model.provider` | string | unset | Provider name in Pi's model registry. Required when `model` is set. |
 | `model.id` | string | unset | Model id in Pi's model registry. Required when `model` is set. |
 | `model.thinking` | enum | unset; workers fall back to `low` | Optional reasoning/thinking level for memory workers. |
+| `showWorkerNotifications` | boolean | `true` | Shows routine observer, reflector, and dropper progress notifications. |
 | `passive` | boolean | `false` | Disables proactive background memory and auto-compaction triggers. |
 | `debugLog` | boolean | `false` | Writes best-effort per-session extension debug events to Pi's agent directory. |
 
@@ -146,6 +148,12 @@ Set `model` when you want the observer, reflector, and dropper to use a cheaper 
 ```
 
 `provider` and `id` must both be non-empty strings. `thinking` is optional. If the configured model cannot be resolved, the runtime attempts to fall back to the current session model and notifies once. If no usable model or API key is available, the relevant background worker skips/fails safely rather than inventing memory.
+
+## `showWorkerNotifications`
+
+Default: `true`.
+
+When `false`, the extension hides routine observer, reflector, and dropper progress notifications. Model fallback/unavailability, no-output warnings, worker failures, compaction notifications, and explicit `/om:*` command output remain visible.
 
 ## `passive`
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -40,6 +40,7 @@ export interface Config {
 	observationsPoolTargetTokens: number;
 	agentMaxTurns: number;
 	model?: ConfiguredModel;
+	showWorkerNotifications: boolean;
 	passive: boolean;
 	debugLog: boolean;
 }
@@ -53,6 +54,7 @@ export const DEFAULTS: Config = {
 	observationsPoolMaxTokens: 20_000,
 	observationsPoolTargetTokens: 10_000,
 	agentMaxTurns: 16,
+	showWorkerNotifications: true,
 	passive: false,
 	debugLog: false,
 };
@@ -148,6 +150,7 @@ function normalizeSettingsConfig(value: Record<string, unknown>): Partial<Config
 	}
 	const ratio = validRatioOrUndefined(value.compactAfterTokensRatio);
 	if (ratio !== undefined) normalized.compactAfterTokensRatio = ratio;
+	if (typeof value.showWorkerNotifications === "boolean") normalized.showWorkerNotifications = value.showWorkerNotifications;
 	if (typeof value.passive === "boolean") normalized.passive = value.passive;
 	if (typeof value.debugLog === "boolean") normalized.debugLog = value.debugLog;
 	const model = normalizeModel(value.model);

--- a/src/hooks/consolidation-trigger.ts
+++ b/src/hooks/consolidation-trigger.ts
@@ -74,6 +74,10 @@ function anyStageDue(entries: Entry[], runtime: Runtime): boolean {
 		|| rawTokensSinceReflectionCoverage(entries) >= runtime.config.reflectAfterTokens;
 }
 
+function shouldNotifyWorker(runtime: Runtime, ctx: ConsolidationCtx): boolean {
+	return runtime.config.showWorkerNotifications && ctx.hasUI;
+}
+
 function makeModelResolver(runtime: Runtime, ctx: ConsolidationCtx): (stage: "observer" | "reflector" | "dropper") => Promise<ResolvedModel | undefined> {
 	let cached: ResolveResult | undefined;
 	return async (stage) => {
@@ -200,7 +204,7 @@ async function runObserverStage(
 	const priorReflections = memory.reflections.map(reflectionToSummaryLine);
 	const priorObservations = memory.observations.map(observationToSummaryLine);
 
-	if (ctx.hasUI) ctx.ui?.notify(
+	if (shouldNotifyWorker(runtime, ctx)) ctx.ui?.notify(
 		`Observational memory: observer running on ~${tokens.toLocaleString()}-token chunk`,
 		"info",
 	);
@@ -245,7 +249,7 @@ async function runObserverStage(
 	});
 	appendEntry(pi, OM_OBSERVATIONS_RECORDED, data);
 	debugLog("observer.appended", { count: observations.length, coversUpToId });
-	if (ctx.hasUI) ctx.ui?.notify(
+	if (shouldNotifyWorker(runtime, ctx)) ctx.ui?.notify(
 		`Observational memory: ${observations.length} observation${observations.length === 1 ? "" : "s"} recorded`,
 		"info",
 	);
@@ -265,7 +269,7 @@ async function runReflectorStage(
 	const observationCoverageId = latestCoverageMarkerId(entries, OM_OBSERVATIONS_RECORDED);
 	if (!observationCoverageId) return { outcome: "continue", sameRunReflections: [] };
 
-	if (ctx.hasUI) ctx.ui?.notify(
+	if (shouldNotifyWorker(runtime, ctx)) ctx.ui?.notify(
 		`Observational memory: reflector running (~${reflectionTokens.toLocaleString()} tokens)`,
 		"info",
 	);
@@ -337,7 +341,7 @@ async function runDropperStage(
 		maxDropsAllowed: metrics.maxDropsAllowed,
 	});
 
-	if (ctx.hasUI) ctx.ui?.notify(
+	if (shouldNotifyWorker(runtime, ctx)) ctx.ui?.notify(
 		`Observational memory: dropper running after reflection — active observation pool ~${metrics.observationTokens.toLocaleString()} / ${metrics.targetTokens.toLocaleString()} target tokens (${Math.round(metrics.fullness * 100).toLocaleString()}%)`,
 		"info",
 	);

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -44,6 +44,7 @@ describe("V3 config", () => {
 			observationsPoolMaxTokens: 20000,
 			observationsPoolTargetTokens: 10000,
 			agentMaxTurns: 16,
+			showWorkerNotifications: true,
 			passive: false,
 			debugLog: false,
 		});
@@ -60,6 +61,7 @@ describe("V3 config", () => {
 				observationsPoolTargetTokens: 15,
 				agentMaxTurns: 5,
 				model: { provider: "anthropic", id: "global", thinking: "medium" },
+				showWorkerNotifications: true,
 				passive: false,
 				debugLog: true,
 			},
@@ -68,6 +70,7 @@ describe("V3 config", () => {
 			"observational-memory": {
 				observeAfterTokens: 100,
 				model: { provider: "openai", id: "project", thinking: "low" },
+				showWorkerNotifications: false,
 			},
 		});
 
@@ -79,6 +82,7 @@ describe("V3 config", () => {
 			observationsPoolTargetTokens: 15,
 			agentMaxTurns: 5,
 			model: { provider: "openai", id: "project", thinking: "low" },
+			showWorkerNotifications: false,
 			passive: true,
 			debugLog: true,
 		});
@@ -94,6 +98,7 @@ describe("V3 config", () => {
 				observationsPoolTargetTokens: "10000",
 				agentMaxTurns: null,
 				model: { provider: "anthropic", id: "", thinking: "huge" },
+				showWorkerNotifications: "no",
 				passive: "yes",
 				debugLog: "true",
 			},

--- a/tests/consolidation-trigger.test.ts
+++ b/tests/consolidation-trigger.test.ts
@@ -41,6 +41,7 @@ function setup(args: {
 	reflectAfterTokens?: number;
 	observationsPoolMaxTokens?: number;
 	observationsPoolTargetTokens?: number;
+	showWorkerNotifications?: boolean;
 	passive?: boolean;
 	consolidationInFlight?: boolean;
 	appendEntryReturnsId?: boolean;
@@ -60,6 +61,7 @@ function setup(args: {
 	let launchedWork: (() => Promise<void>) | undefined;
 	const runtime = {
 		config: {
+			showWorkerNotifications: args.showWorkerNotifications ?? true,
 			passive: args.passive ?? false,
 			debugLog: false,
 			observeAfterTokens: args.observeAfterTokens ?? 1,
@@ -238,6 +240,55 @@ describe("V3 consolidation trigger", () => {
 		expect(pi.appendEntry).not.toHaveBeenCalled();
 		expect(mockAgents.runReflector).not.toHaveBeenCalled();
 		expect(mockAgents.runDropper).not.toHaveBeenCalled();
+	});
+
+	it("shows routine worker notifications by default", async () => {
+		const newRef = reflection("ffffffffffff", ["aaaaaaaaaaaa"]);
+		mockAgents.runObserver.mockResolvedValueOnce([obsA]);
+		mockAgents.runReflector.mockResolvedValueOnce([newRef]);
+		mockAgents.runDropper.mockResolvedValueOnce(["aaaaaaaaaaaa"]);
+		const entries = [textCustomMessage("raw-1", "aaaaaaaa")];
+		const { fire, runLaunchedWork, ctx } = setup({ entries, observationsPoolTargetTokens: 5 });
+
+		fire();
+		await runLaunchedWork();
+
+		expect(ctx.ui.notify.mock.calls).toEqual([
+			["Observational memory: observer running on ~2-token chunk", "info"],
+			["Observational memory: 1 observation recorded", "info"],
+			["Observational memory: reflector running (~2 tokens)", "info"],
+			["Observational memory: dropper running after reflection — active observation pool ~10 / 5 target tokens (200%)", "info"],
+		]);
+	});
+
+	it("suppresses routine worker notifications without hiding warnings", async () => {
+		const newRef = reflection("ffffffffffff", ["aaaaaaaaaaaa"]);
+		mockAgents.runObserver.mockResolvedValueOnce([obsA]);
+		mockAgents.runReflector.mockResolvedValueOnce([newRef]);
+		mockAgents.runDropper.mockResolvedValueOnce(["aaaaaaaaaaaa"]);
+		const entries = [textCustomMessage("raw-1", "aaaaaaaa")];
+		const quiet = setup({ entries, observationsPoolTargetTokens: 5, showWorkerNotifications: false });
+
+		quiet.fire();
+		await quiet.runLaunchedWork();
+
+		expect(mockAgents.runObserver).toHaveBeenCalledOnce();
+		expect(mockAgents.runReflector).toHaveBeenCalledOnce();
+		expect(mockAgents.runDropper).toHaveBeenCalledOnce();
+		expect(quiet.ctx.ui.notify).not.toHaveBeenCalled();
+
+		mockAgents.runObserver.mockReset();
+		mockAgents.runObserver.mockResolvedValueOnce(undefined);
+		const noOutput = setup({ entries, reflectAfterTokens: 999, showWorkerNotifications: false });
+
+		noOutput.fire();
+		await noOutput.runLaunchedWork();
+
+		expect(noOutput.ctx.ui.notify).toHaveBeenCalledOnce();
+		expect(noOutput.ctx.ui.notify).toHaveBeenCalledWith(
+			"Observational memory: observer returned no observations",
+			"warning",
+		);
 	});
 
 	it("model resolution failure skips appending and notifies once", async () => {


### PR DESCRIPTION
## Summary

- add `showWorkerNotifications`, defaulting to `true`
- when disabled, suppress only routine observer/reflector/dropper progress notifications
- preserve model, no-output, worker-failure, compaction, and explicit command notifications

Closes #26.

## Why this scope

Routine background-worker notifications can be frequent in long sessions, especially the observer start/result pair at the default 10,000-token cadence. They report expected activity and require no user action.

This setting intentionally does **not** filter notifications by severity and does not create a general quiet mode. Messages that explain failures, potential observation gaps, unusual compaction outcomes, or user-requested status remain visible.

With:

```json
{
  "observational-memory": {
    "showWorkerNotifications": false
  }
}
```

only these routine messages are hidden:

- `observer running ...`
- `N observations recorded`
- `reflector running ...`
- `dropper running ...`

The default remains unchanged for backwards compatibility.

## Implementation

The implementation is deliberately small:

- one validated boolean setting in the existing config path
- one local predicate shared by the four routine notification sites
- no changes to worker scheduling, memory semantics, error handling, compaction, or commands

## Verification

- `npm run typecheck`
- `npm test` — 21 test files, 198 tests passed

Tests cover both sides of the contract: the default still emits all four routine notifications, while disabling the setting leaves the full observer/reflector/dropper pipeline running and preserves the observer no-output warning.
