### PR TITLE
Log LLM stream errors from observer/reflector/dropper runs

### DIFF
--- a/src/agents/dropper/agent.ts
+++ b/src/agents/dropper/agent.ts
@@ -5,6 +5,7 @@ import { streamSimple } from "@earendil-works/pi-ai/compat";
 import type { Static } from "typebox";
 import { debugLog } from "../../debug-log.js";
 import { AGENT_LOOP_MAX_TOKENS, boundedMaxTokens } from "../../model-budget.js";
+import { logAgentStreamError } from "../stream-errors.js";
 import { reflectionToSummaryLine, type Observation, type Reflection } from "../../session-ledger/index.js";
 import { DROPPER_SYSTEM } from "./prompts.js";
 import {
@@ -251,8 +252,9 @@ export async function runDropper(args: RunDropperArgs): Promise<string[] | undef
 
 	const loop = args.agentLoop ?? agentLoop;
 	const stream = loop(prompts, context, config, signal, streamSimple);
-	for await (const _event of stream) {
+	for await (const event of stream) {
 		// Tool execution collects candidate ids.
+		logAgentStreamError("dropper", event);
 	}
 	await stream.result();
 	const droppedIds = selectDropCandidates(proposedDropIds, observations, maxDropsAllowed, reflections);

--- a/src/agents/observer/agent.ts
+++ b/src/agents/observer/agent.ts
@@ -4,6 +4,7 @@ import { Type } from "@earendil-works/pi-ai";
 import { streamSimple } from "@earendil-works/pi-ai/compat";
 import type { Static } from "typebox";
 import { hashId } from "../../ids.js";
+import { logAgentStreamError } from "../stream-errors.js";
 import { AGENT_LOOP_MAX_TOKENS, boundedMaxTokens } from "../../model-budget.js";
 import { OBSERVER_SYSTEM } from "./prompts.js";
 import { nowTimestamp, truncateRecordContent } from "../../serialize.js";
@@ -188,8 +189,9 @@ ${conversation}`;
 
 	const loop = args.agentLoop ?? agentLoop;
 	const stream = loop(prompts, context, config, signal, streamSimple);
-	for await (const _event of stream) {
+	for await (const event of stream) {
 		// Drain events; the tool's execute already collects records.
+		logAgentStreamError("observer", event);
 	}
 	await stream.result();
 

--- a/src/agents/reflector/agent.ts
+++ b/src/agents/reflector/agent.ts
@@ -5,6 +5,7 @@ import { streamSimple } from "@earendil-works/pi-ai/compat";
 import type { Static } from "typebox";
 import { debugLog } from "../../debug-log.js";
 import { hashId } from "../../ids.js";
+import { logAgentStreamError } from "../stream-errors.js";
 import { AGENT_LOOP_MAX_TOKENS, boundedMaxTokens } from "../../model-budget.js";
 import { truncateRecordContent } from "../../serialize.js";
 import { REFLECTOR_SYSTEM } from "./prompts.js";
@@ -184,8 +185,9 @@ export async function runReflector(args: RunReflectorArgs): Promise<Reflection[]
 
 	const loop = args.agentLoop ?? agentLoop;
 	const stream = loop(prompts, context, config, signal, streamSimple);
-	for await (const _event of stream) {
+	for await (const event of stream) {
 		// Tool execution collects records.
+		logAgentStreamError("reflector", event);
 	}
 	await stream.result();
 	const acceptedReflections = Array.from(accumulated.values());

--- a/src/agents/stream-errors.ts
+++ b/src/agents/stream-errors.ts
@@ -1,0 +1,22 @@
+import type { AgentEvent } from "@earendil-works/pi-agent-core";
+import { debugLog } from "../debug-log.js";
+
+/**
+ * Surface LLM failures from an agent-loop event stream.
+ *
+ * When the underlying LLM call fails, the loop ends the stream with a final
+ * assistant message whose stopReason is "error" (or "aborted") — no exception
+ * is thrown. Without this hook the drain loops treat such runs exactly like
+ * "the model chose not to call the tool", which hides the real cause
+ * (rate limits, oversized prompts, auth failures, ...) from the debug log.
+ */
+export function logAgentStreamError(stage: "observer" | "reflector" | "dropper", event: AgentEvent): void {
+	if (event.type !== "message_end") return;
+	const message = event.message;
+	if (message.role !== "assistant") return;
+	if (message.stopReason !== "error" && message.stopReason !== "aborted") return;
+	debugLog(`${stage}.stream_error`, {
+		stopReason: message.stopReason,
+		errorMessage: message.errorMessage,
+	});
+}

--- a/tests/stream-errors.test.ts
+++ b/tests/stream-errors.test.ts
@@ -1,0 +1,127 @@
+import { mkdirSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mock = vi.hoisted(() => ({ agentDir: "" }));
+
+vi.mock("@earendil-works/pi-coding-agent", () => ({
+	getAgentDir: () => mock.agentDir,
+	estimateTokens: () => 0,
+}));
+
+import { logAgentStreamError } from "../src/agents/stream-errors.js";
+import { runObserver } from "../src/agents/observer/agent.js";
+import { debugLogRelativePath, withDebugLogContext } from "../src/debug-log.js";
+
+describe("agent stream error logging", () => {
+	let root: string;
+
+	beforeEach(() => {
+		root = `${tmpdir()}/om-stream-errors-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+		mock.agentDir = join(root, "agent");
+		mkdirSync(mock.agentDir, { recursive: true });
+	});
+
+	afterEach(() => {
+		rmSync(root, { recursive: true, force: true });
+	});
+
+	function readLoggedEvents(sessionId: string): Array<{ event: string; data: Record<string, unknown> }> {
+		const path = join(mock.agentDir, debugLogRelativePath({ sessionId }));
+		return readFileSync(path, "utf-8")
+			.trim()
+			.split("\n")
+			.filter(Boolean)
+			.map((line) => JSON.parse(line));
+	}
+
+	it("logs assistant message_end with stopReason error, prefixed with the stage", () => {
+		withDebugLogContext({ enabled: true, sessionId: "session-stream-1" }, () => {
+			logAgentStreamError("observer", {
+				type: "message_end",
+				message: {
+					role: "assistant",
+					content: [],
+					stopReason: "error",
+					errorMessage: "prompt is too long: 5198507 tokens > 1000000 maximum",
+				} as any,
+			});
+		});
+
+		const events = readLoggedEvents("session-stream-1");
+		expect(events).toHaveLength(1);
+		expect(events[0].event).toBe("observer.stream_error");
+		expect(events[0].data).toMatchObject({
+			stopReason: "error",
+			errorMessage: "prompt is too long: 5198507 tokens > 1000000 maximum",
+		});
+	});
+
+	it("logs aborted runs and uses the caller's stage name", () => {
+		withDebugLogContext({ enabled: true, sessionId: "session-stream-2" }, () => {
+			logAgentStreamError("reflector", {
+				type: "message_end",
+				message: { role: "assistant", content: [], stopReason: "aborted" } as any,
+			});
+		});
+
+		const events = readLoggedEvents("session-stream-2");
+		expect(events).toHaveLength(1);
+		expect(events[0].event).toBe("reflector.stream_error");
+		expect(events[0].data).toMatchObject({ stopReason: "aborted" });
+	});
+
+	it("ignores successful assistant messages, non-assistant messages, and other events", () => {
+		withDebugLogContext({ enabled: true, sessionId: "session-stream-3" }, () => {
+			logAgentStreamError("observer", {
+				type: "message_end",
+				message: { role: "assistant", content: [], stopReason: "stop" } as any,
+			});
+			logAgentStreamError("observer", {
+				type: "message_end",
+				message: { role: "user", content: [], timestamp: 0 } as any,
+			});
+			logAgentStreamError("observer", { type: "turn_start" });
+			// One real error so the log file exists and we can assert nothing else landed.
+			logAgentStreamError("observer", {
+				type: "message_end",
+				message: { role: "assistant", content: [], stopReason: "error", errorMessage: "marker" } as any,
+			});
+		});
+
+		const events = readLoggedEvents("session-stream-3");
+		expect(events).toHaveLength(1);
+		expect(events[0].data).toMatchObject({ errorMessage: "marker" });
+	});
+
+	it("runObserver logs a stream_error when the loop ends with an errored assistant message", async () => {
+		const failingLoop = (() => ({
+			async *[Symbol.asyncIterator]() {
+				yield {
+					type: "message_end",
+					message: { role: "assistant", content: [], stopReason: "error", errorMessage: "upstream 400" },
+				};
+			},
+			result: async () => ({}),
+		})) as any;
+
+		await withDebugLogContext({ enabled: true, sessionId: "session-stream-4" }, async () => {
+			const observations = await runObserver({
+				model: {} as any,
+				apiKey: "test",
+				priorReflections: [],
+				priorObservations: [],
+				chunk: "[Source entry id: entry-a]\nSome content.",
+				allowedSourceEntryIds: ["entry-a"],
+				agentLoop: failingLoop,
+			});
+			expect(observations).toBeUndefined();
+		});
+
+		const events = readLoggedEvents("session-stream-4");
+		expect(events).toHaveLength(1);
+		expect(events[0].event).toBe("observer.stream_error");
+		expect(events[0].data).toMatchObject({ stopReason: "error", errorMessage: "upstream 400" });
+	});
+});


### PR DESCRIPTION
Debugging aid for #32.

## Problem

When the observer/reflector/dropper LLM call fails, agent-core doesn't throw — it ends the stream with a final assistant message carrying `stopReason: "error"` and the error text. The drain loops ignored every event, so a failed API call looked exactly like "the model chose to record nothing". In #32 this cost me two days: 383 failed observer calls, and the only visible symptom was the generic "observer returned no observations" warning.

## Change

Small shared helper (`src/agents/stream-errors.ts`) that watches `message_end` events while draining and emits a `<stage>.stream_error` debug event with `stopReason` and `errorMessage`. Wired into all three agents.

With this in place, the #32 failure shows up in the debug log as:

```
{"event":"observer.stream_error","data":{"stopReason":"error","errorMessage":"prompt is too long: 5198507 tokens > 1000000 maximum"}}
```

instead of a bare `observer.empty`.

No behavior change otherwise — logging only, and only when `debugLog` is enabled.

## Tests

`tests/stream-errors.test.ts`: error/aborted messages are logged with the right stage prefix, successful and non-assistant messages are ignored, and an end-to-end `runObserver` case with a failing fake loop. `npm run typecheck` and the full suite (200 tests) pass.

---

Disclosure: written with AI assistance (Claude, driving the debugging session in #32). I've reviewed the diff and run the tests locally.
