### PR TITLE
Retry observer on transient LLM errors before giving up

### DIFF
--- a/src/agents/dropper/agent.ts
+++ b/src/agents/dropper/agent.ts
@@ -4,6 +4,7 @@ import { Type } from "@earendil-works/pi-ai";
 import type { Static } from "typebox";
 import { debugLog } from "../../debug-log.js";
 import { AGENT_LOOP_MAX_TOKENS, boundedMaxTokens } from "../../model-budget.js";
+import { logAgentStreamError } from "../stream-errors.js";
 import { reflectionToSummaryLine, type Observation, type Reflection } from "../../session-ledger/index.js";
 import { DROPPER_SYSTEM } from "./prompts.js";
 import {
@@ -250,8 +251,9 @@ export async function runDropper(args: RunDropperArgs): Promise<string[] | undef
 
 	const loop = args.agentLoop ?? agentLoop;
 	const stream = loop(prompts, context, config, signal);
-	for await (const _event of stream) {
+	for await (const event of stream) {
 		// Tool execution collects candidate ids.
+		logAgentStreamError("dropper", event);
 	}
 	await stream.result();
 	const droppedIds = selectDropCandidates(proposedDropIds, observations, maxDropsAllowed, reflections);

--- a/src/agents/observer/agent.ts
+++ b/src/agents/observer/agent.ts
@@ -3,6 +3,7 @@ import type { Message, Model, ModelThinkingLevel } from "@earendil-works/pi-ai";
 import { Type } from "@earendil-works/pi-ai";
 import type { Static } from "typebox";
 import { hashId } from "../../ids.js";
+import { logAgentStreamError } from "../stream-errors.js";
 import { AGENT_LOOP_MAX_TOKENS, boundedMaxTokens } from "../../model-budget.js";
 import { OBSERVER_SYSTEM } from "./prompts.js";
 import { nowTimestamp, truncateRecordContent } from "../../serialize.js";
@@ -187,8 +188,9 @@ ${conversation}`;
 
 	const loop = args.agentLoop ?? agentLoop;
 	const stream = loop(prompts, context, config, signal);
-	for await (const _event of stream) {
+	for await (const event of stream) {
 		// Drain events; the tool's execute already collects records.
+		logAgentStreamError("observer", event);
 	}
 	await stream.result();
 

--- a/src/agents/observer/agent.ts
+++ b/src/agents/observer/agent.ts
@@ -2,8 +2,9 @@ import { agentLoop, type AgentContext, type AgentLoopConfig, type AgentTool } fr
 import type { Message, Model, ModelThinkingLevel } from "@earendil-works/pi-ai";
 import { Type } from "@earendil-works/pi-ai";
 import type { Static } from "typebox";
+import { debugLog } from "../../debug-log.js";
 import { hashId } from "../../ids.js";
-import { logAgentStreamError } from "../stream-errors.js";
+import { isTransientLlmError, logAgentStreamError, type LlmStreamError } from "../stream-errors.js";
 import { AGENT_LOOP_MAX_TOKENS, boundedMaxTokens } from "../../model-budget.js";
 import { OBSERVER_SYSTEM } from "./prompts.js";
 import { nowTimestamp, truncateRecordContent } from "../../serialize.js";
@@ -22,7 +23,13 @@ interface RunObserverArgs {
 	agentLoop?: typeof agentLoop;
 	maxTurns?: number;
 	thinkingLevel?: ModelThinkingLevel;
+	/** Delays between transient-error retries. Test injection point. */
+	retryDelaysMs?: number[];
+	/** Sleep implementation. Test injection point. */
+	sleep?: (ms: number) => Promise<void>;
 }
+
+const DEFAULT_RETRY_DELAYS_MS = [2_000, 5_000];
 
 const RelevanceSchema = Type.Union([
 	Type.Literal("low"),
@@ -187,12 +194,35 @@ ${conversation}`;
 	};
 
 	const loop = args.agentLoop ?? agentLoop;
-	const stream = loop(prompts, context, config, signal);
-	for await (const event of stream) {
-		// Drain events; the tool's execute already collects records.
-		logAgentStreamError("observer", event);
+	const retryDelays = args.retryDelaysMs ?? DEFAULT_RETRY_DELAYS_MS;
+	const sleep = args.sleep ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+
+	// Transient provider failures (overloaded, 5xx, connection drops) are worth
+	// a short retry instead of surfacing a spurious "no observations" warning
+	// and waiting for the next turn. Request defects and non-transient errors
+	// still fail immediately. agentLoop copies the context's message array, so
+	// re-running with the same context is safe.
+	for (let attempt = 0; ; attempt++) {
+		let streamError: LlmStreamError | undefined;
+		const stream = loop(prompts, context, config, signal);
+		for await (const event of stream) {
+			// Drain events; the tool's execute already collects records.
+			streamError = logAgentStreamError("observer", event) ?? streamError;
+		}
+		await stream.result();
+
+		if (accumulated.size > 0) break;
+		if (!streamError || !isTransientLlmError(streamError)) break;
+		if (attempt >= retryDelays.length || signal?.aborted) break;
+		const delayMs = retryDelays[attempt];
+		debugLog("observer.transient_retry", {
+			attempt: attempt + 1,
+			maxAttempts: retryDelays.length + 1,
+			delayMs,
+			errorMessage: streamError.errorMessage,
+		});
+		await sleep(delayMs);
 	}
-	await stream.result();
 
 	if (accumulated.size === 0) return undefined;
 	return Array.from(accumulated.values());

--- a/src/agents/reflector/agent.ts
+++ b/src/agents/reflector/agent.ts
@@ -4,6 +4,7 @@ import { Type } from "@earendil-works/pi-ai";
 import type { Static } from "typebox";
 import { debugLog } from "../../debug-log.js";
 import { hashId } from "../../ids.js";
+import { logAgentStreamError } from "../stream-errors.js";
 import { AGENT_LOOP_MAX_TOKENS, boundedMaxTokens } from "../../model-budget.js";
 import { truncateRecordContent } from "../../serialize.js";
 import { REFLECTOR_SYSTEM } from "./prompts.js";
@@ -183,8 +184,9 @@ export async function runReflector(args: RunReflectorArgs): Promise<Reflection[]
 
 	const loop = args.agentLoop ?? agentLoop;
 	const stream = loop(prompts, context, config, signal);
-	for await (const _event of stream) {
+	for await (const event of stream) {
 		// Tool execution collects records.
+		logAgentStreamError("reflector", event);
 	}
 	await stream.result();
 	const acceptedReflections = Array.from(accumulated.values());

--- a/src/agents/stream-errors.ts
+++ b/src/agents/stream-errors.ts
@@ -1,0 +1,22 @@
+import type { AgentEvent } from "@earendil-works/pi-agent-core";
+import { debugLog } from "../debug-log.js";
+
+/**
+ * Surface LLM failures from an agent-loop event stream.
+ *
+ * When the underlying LLM call fails, the loop ends the stream with a final
+ * assistant message whose stopReason is "error" (or "aborted") — no exception
+ * is thrown. Without this hook the drain loops treat such runs exactly like
+ * "the model chose not to call the tool", which hides the real cause
+ * (rate limits, oversized prompts, auth failures, ...) from the debug log.
+ */
+export function logAgentStreamError(stage: "observer" | "reflector" | "dropper", event: AgentEvent): void {
+	if (event.type !== "message_end") return;
+	const message = event.message;
+	if (message.role !== "assistant") return;
+	if (message.stopReason !== "error" && message.stopReason !== "aborted") return;
+	debugLog(`${stage}.stream_error`, {
+		stopReason: message.stopReason,
+		errorMessage: message.errorMessage,
+	});
+}

--- a/src/agents/stream-errors.ts
+++ b/src/agents/stream-errors.ts
@@ -1,6 +1,23 @@
 import type { AgentEvent } from "@earendil-works/pi-agent-core";
 import { debugLog } from "../debug-log.js";
 
+export interface LlmStreamError {
+	stopReason: "error" | "aborted";
+	errorMessage?: string;
+}
+
+/**
+ * Provider failures worth retrying after a short delay: transient capacity or
+ * connectivity problems, not request defects. Mirrors the spirit of Pi's own
+ * retryable-error detection for the main agent (see compaction-trigger.ts).
+ */
+const TRANSIENT_LLM_ERROR_RE =
+	/overloaded|rate.?limit|too many requests|429|500|502|503|504|service.?unavailable|server.?error|internal.?error|no available accounts|network.?error|connection.?(error|refused|lost|reset)|fetch failed|socket hang up|upstream.?connect|reset before headers|other side closed|ended without|timed? out|timeout|terminated/i;
+
+export function isTransientLlmError(error: LlmStreamError): boolean {
+	return error.stopReason === "error" && typeof error.errorMessage === "string" && TRANSIENT_LLM_ERROR_RE.test(error.errorMessage);
+}
+
 /**
  * Surface LLM failures from an agent-loop event stream.
  *
@@ -10,13 +27,14 @@ import { debugLog } from "../debug-log.js";
  * "the model chose not to call the tool", which hides the real cause
  * (rate limits, oversized prompts, auth failures, ...) from the debug log.
  */
-export function logAgentStreamError(stage: "observer" | "reflector" | "dropper", event: AgentEvent): void {
-	if (event.type !== "message_end") return;
+export function logAgentStreamError(stage: "observer" | "reflector" | "dropper", event: AgentEvent): LlmStreamError | undefined {
+	if (event.type !== "message_end") return undefined;
 	const message = event.message;
-	if (message.role !== "assistant") return;
-	if (message.stopReason !== "error" && message.stopReason !== "aborted") return;
+	if (message.role !== "assistant") return undefined;
+	if (message.stopReason !== "error" && message.stopReason !== "aborted") return undefined;
 	debugLog(`${stage}.stream_error`, {
 		stopReason: message.stopReason,
 		errorMessage: message.errorMessage,
 	});
+	return { stopReason: message.stopReason, errorMessage: message.errorMessage };
 }

--- a/tests/stream-errors.test.ts
+++ b/tests/stream-errors.test.ts
@@ -1,0 +1,127 @@
+import { mkdirSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mock = vi.hoisted(() => ({ agentDir: "" }));
+
+vi.mock("@earendil-works/pi-coding-agent", () => ({
+	getAgentDir: () => mock.agentDir,
+	estimateTokens: () => 0,
+}));
+
+import { logAgentStreamError } from "../src/agents/stream-errors.js";
+import { runObserver } from "../src/agents/observer/agent.js";
+import { debugLogRelativePath, withDebugLogContext } from "../src/debug-log.js";
+
+describe("agent stream error logging", () => {
+	let root: string;
+
+	beforeEach(() => {
+		root = `${tmpdir()}/om-stream-errors-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+		mock.agentDir = join(root, "agent");
+		mkdirSync(mock.agentDir, { recursive: true });
+	});
+
+	afterEach(() => {
+		rmSync(root, { recursive: true, force: true });
+	});
+
+	function readLoggedEvents(sessionId: string): Array<{ event: string; data: Record<string, unknown> }> {
+		const path = join(mock.agentDir, debugLogRelativePath({ sessionId }));
+		return readFileSync(path, "utf-8")
+			.trim()
+			.split("\n")
+			.filter(Boolean)
+			.map((line) => JSON.parse(line));
+	}
+
+	it("logs assistant message_end with stopReason error, prefixed with the stage", () => {
+		withDebugLogContext({ enabled: true, sessionId: "session-stream-1" }, () => {
+			logAgentStreamError("observer", {
+				type: "message_end",
+				message: {
+					role: "assistant",
+					content: [],
+					stopReason: "error",
+					errorMessage: "prompt is too long: 5198507 tokens > 1000000 maximum",
+				} as any,
+			});
+		});
+
+		const events = readLoggedEvents("session-stream-1");
+		expect(events).toHaveLength(1);
+		expect(events[0].event).toBe("observer.stream_error");
+		expect(events[0].data).toMatchObject({
+			stopReason: "error",
+			errorMessage: "prompt is too long: 5198507 tokens > 1000000 maximum",
+		});
+	});
+
+	it("logs aborted runs and uses the caller's stage name", () => {
+		withDebugLogContext({ enabled: true, sessionId: "session-stream-2" }, () => {
+			logAgentStreamError("reflector", {
+				type: "message_end",
+				message: { role: "assistant", content: [], stopReason: "aborted" } as any,
+			});
+		});
+
+		const events = readLoggedEvents("session-stream-2");
+		expect(events).toHaveLength(1);
+		expect(events[0].event).toBe("reflector.stream_error");
+		expect(events[0].data).toMatchObject({ stopReason: "aborted" });
+	});
+
+	it("ignores successful assistant messages, non-assistant messages, and other events", () => {
+		withDebugLogContext({ enabled: true, sessionId: "session-stream-3" }, () => {
+			logAgentStreamError("observer", {
+				type: "message_end",
+				message: { role: "assistant", content: [], stopReason: "stop" } as any,
+			});
+			logAgentStreamError("observer", {
+				type: "message_end",
+				message: { role: "user", content: [], timestamp: 0 } as any,
+			});
+			logAgentStreamError("observer", { type: "turn_start" });
+			// One real error so the log file exists and we can assert nothing else landed.
+			logAgentStreamError("observer", {
+				type: "message_end",
+				message: { role: "assistant", content: [], stopReason: "error", errorMessage: "marker" } as any,
+			});
+		});
+
+		const events = readLoggedEvents("session-stream-3");
+		expect(events).toHaveLength(1);
+		expect(events[0].data).toMatchObject({ errorMessage: "marker" });
+	});
+
+	it("runObserver logs a stream_error when the loop ends with an errored assistant message", async () => {
+		const failingLoop = (() => ({
+			async *[Symbol.asyncIterator]() {
+				yield {
+					type: "message_end",
+					message: { role: "assistant", content: [], stopReason: "error", errorMessage: "upstream 400" },
+				};
+			},
+			result: async () => ({}),
+		})) as any;
+
+		await withDebugLogContext({ enabled: true, sessionId: "session-stream-4" }, async () => {
+			const observations = await runObserver({
+				model: {} as any,
+				apiKey: "test",
+				priorReflections: [],
+				priorObservations: [],
+				chunk: "[Source entry id: entry-a]\nSome content.",
+				allowedSourceEntryIds: ["entry-a"],
+				agentLoop: failingLoop,
+			});
+			expect(observations).toBeUndefined();
+		});
+
+		const events = readLoggedEvents("session-stream-4");
+		expect(events).toHaveLength(1);
+		expect(events[0].event).toBe("observer.stream_error");
+		expect(events[0].data).toMatchObject({ stopReason: "error", errorMessage: "upstream 400" });
+	});
+});

--- a/tests/stream-errors.test.ts
+++ b/tests/stream-errors.test.ts
@@ -124,4 +124,81 @@ describe("agent stream error logging", () => {
 		expect(events[0].event).toBe("observer.stream_error");
 		expect(events[0].data).toMatchObject({ stopReason: "error", errorMessage: "upstream 400" });
 	});
+
+	it("runObserver retries transient errors and succeeds on a later attempt", async () => {
+		let calls = 0;
+		const flakyLoop = ((_prompts: any[], context: any) => ({
+			async *[Symbol.asyncIterator]() {
+				calls++;
+				if (calls < 3) {
+					yield {
+						type: "message_end",
+						message: { role: "assistant", content: [], stopReason: "error", errorMessage: '503 {"error":{"message":"No available accounts"}}' },
+					};
+					return;
+				}
+				await context.tools[0].execute("tool-1", {
+					observations: [{ timestamp: "2026-05-02 10:30", content: "Recovered after retry.", relevance: "high", sourceEntryIds: ["entry-a"] }],
+				});
+			},
+			result: async () => ({}),
+		})) as any;
+
+		const slept: number[] = [];
+		await withDebugLogContext({ enabled: true, sessionId: "session-stream-5" }, async () => {
+			const observations = await runObserver({
+				model: {} as any,
+				apiKey: "test",
+				priorReflections: [],
+				priorObservations: [],
+				chunk: "[Source entry id: entry-a]\nSome content.",
+				allowedSourceEntryIds: ["entry-a"],
+				agentLoop: flakyLoop,
+				retryDelaysMs: [10, 20],
+				sleep: async (ms) => { slept.push(ms); },
+			});
+			expect(observations).toHaveLength(1);
+			expect(observations?.[0].content).toBe("Recovered after retry.");
+		});
+
+		expect(calls).toBe(3);
+		expect(slept).toEqual([10, 20]);
+		const events = readLoggedEvents("session-stream-5");
+		const retries = events.filter((e) => e.event === "observer.transient_retry");
+		expect(retries).toHaveLength(2);
+		expect(retries[0].data).toMatchObject({ attempt: 1, delayMs: 10 });
+	});
+
+	it("runObserver does not retry non-transient errors", async () => {
+		let calls = 0;
+		const failingLoop = (() => ({
+			async *[Symbol.asyncIterator]() {
+				calls++;
+				yield {
+					type: "message_end",
+					message: { role: "assistant", content: [], stopReason: "error", errorMessage: "400 prompt is too long: 5198507 tokens > 1000000 maximum" },
+				};
+			},
+			result: async () => ({}),
+		})) as any;
+
+		await withDebugLogContext({ enabled: true, sessionId: "session-stream-6" }, async () => {
+			const observations = await runObserver({
+				model: {} as any,
+				apiKey: "test",
+				priorReflections: [],
+				priorObservations: [],
+				chunk: "[Source entry id: entry-a]\nSome content.",
+				allowedSourceEntryIds: ["entry-a"],
+				agentLoop: failingLoop,
+				retryDelaysMs: [10, 20],
+				sleep: async () => {},
+			});
+			expect(observations).toBeUndefined();
+		});
+
+		expect(calls).toBe(1);
+		const events = readLoggedEvents("session-stream-6");
+		expect(events.filter((e) => e.event === "observer.transient_retry")).toHaveLength(0);
+	});
 });


### PR DESCRIPTION
Builds on #33 (branched from it; the first commit here is #33's). Related to the failure mode in #32, but for transient provider errors rather than permanent ones.

## Problem

Right after #33 landed in my local install, it caught a different failure live: my gateway's account pool went empty for a few minutes and every memory-agent call failed with

```
503 {"error":{"message":"No available accounts: no available accounts","type":"api_error"}}
```

Each failure cost the observer its entire run. The user sees the generic "observer returned no observations" warning once per turn for the whole outage, and memory silently falls behind — even though the outage was over in minutes and the very same request succeeds on retry.

Pi's main agent already treats this class of error as retryable (the plugin itself mirrors that list in `compaction-trigger.ts` to avoid compacting between Pi's retry attempts). The background memory agents are the only LLM callers here with zero retry tolerance.

## Change

`runObserver` retries on transient stream errors — overloaded / 429 / 5xx / connection drops / gateway pool exhaustion — with short delays (2s, 5s), then gives up as before. Non-transient errors (invalid request, prompt too long, auth) still fail on the first attempt. Each retry emits an `observer.transient_retry` debug event.

Classification lives in `stream-errors.ts` next to the #33 helper; `logAgentStreamError` now returns the captured error so callers can classify it (previously it only logged).

Scoped to the observer deliberately: it's the stage that loses real data on a failed run (reflector/dropper just wait for the next trigger with nothing lost). Happy to extend to the other two if you'd rather have symmetry.

## Tests

- Transient failure twice then success: three loop calls, both configured delays slept, two `observer.transient_retry` events, observations recorded.
- Non-transient failure: single call, no retry events.
- Delays and sleep are injectable, so tests run instantly.
- `npm run typecheck` and the full suite (202 tests) pass.

---

Disclosure: written with AI assistance (Claude). The 503 case above is from my own session logs, minutes after deploying #33 locally.
