### PR TITLE
fix(runtime): accept headers-based OAuth auth in resolveModel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# Project agent memory
+
+This file is the project's committed home for project-intrinsic agent knowledge: build, test, release, architecture, and sharp-edge notes that should travel with the code.
+
+- Add durable project-specific notes here as they are discovered through real work.
+
+## Model auth (OAuth vs API key)
+
+`src/runtime.ts` `resolveModel` must accept auth that carries EITHER an `apiKey` OR non-empty
+`headers` (e.g. `Authorization: Bearer …`). Pi's OAuth providers (kimi-coding, xai, openai-codex,
+anthropic OAuth, …) return headers-only auth from `getApiKeyAndHeaders`, and pi-ai providers treat a
+caller-supplied `Authorization` header as a substitute apiKey. The acceptance rule mirrors pi's own
+`AgentSession._getRequiredRequestAuth` (`result.auth.apiKey || result.auth.headers`). Do not
+re-introduce a hard `apiKey` requirement — it breaks compaction/consolidation for every OAuth model.
+Tests: `npm test` (vitest); typecheck: `npm run typecheck`.
+
+## Maintaining this file
+
+Keep this file for knowledge useful to almost every future agent session in this project.
+Do not repeat what the codebase already shows; point to the authoritative file or command instead.
+Prefer rewriting or pruning existing entries over appending new ones.
+When updating this file, preserve this bar for all agents and keep entries concise.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ Valid `model.thinking` values are:
 
 If no `model` is configured, memory workers use the session model.
 
-Set `showWorkerNotifications` to `false` to hide routine worker start and completion messages. Model fallback/unavailability, no-output warnings, worker failures, compaction notifications, and explicit `/om:*` command output remain visible.
+Set `showWorkerNotifications` to `false` to hide routine worker start and completion messages (including deliberate-empty observer info messages). Model fallback/unavailability, worker failures (including observer stream errors), compaction notifications, and explicit `/om:*` command output remain visible.
 
 `observationsPoolMaxTokens` and `observationsPoolTargetTokens` intentionally describe different pools. Max tokens control when compaction performs a full fold over visible memory. Target tokens control the folded active observation pool that the dropper maintains after successful reflection. If the target is omitted, it defaults to half of max.
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -70,9 +70,9 @@ Dropping does not delete history. Dropped observations remain recallable from le
 
 ### Observer
 
-The observer runs asynchronously from `turn_end` when raw/source tokens after the latest observation coverage marker reach `observeAfterTokens`.
+The observer runs asynchronously from `turn_end` when raw/source tokens after the latest observation coverage marker reach `observeAfterTokens`. After a deliberate empty result, it waits for another `observeAfterTokens` of source tokens before retrying the uncovered range.
 
-It receives raw/source entries only, validates source ids, and appends a non-empty `om.observations.recorded` entry. If there is nothing worth recording, it writes no entry and the raw range remains eligible for a later observer run.
+It receives an oldest-first chunk of raw/source entries, validates source ids, and appends a non-empty `om.observations.recorded` entry. Chunking targets a fixed 60,000 estimated tokens but always includes at least one entry, so a single oversized entry cannot stall coverage. If there is nothing worth recording, it writes no entry and leaves the raw range uncovered.
 
 ### Reflector
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -147,7 +147,7 @@ Set `model` when you want the observer, reflector, and dropper to use a cheaper 
 }
 ```
 
-`provider` and `id` must both be non-empty strings. `thinking` is optional. If the configured model cannot be resolved, the runtime attempts to fall back to the current session model and notifies once. If no usable model or API key is available, the relevant background worker skips/fails safely rather than inventing memory.
+`provider` and `id` must both be non-empty strings. `thinking` is optional. If the configured model cannot be resolved, the runtime attempts to fall back to the current session model and notifies once. Memory workers accept either an API key or OAuth-style auth headers (e.g. `Authorization: Bearer …`), so OAuth-authenticated providers work without an API key. If no usable model or credentials are available, the relevant background worker skips/fails safely rather than inventing memory.
 
 ## `showWorkerNotifications`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -77,7 +77,7 @@ Default: `10000`.
 
 The observer runs from Pi's `turn_end` hook. It counts raw/source tokens after the latest `om.observations.recorded.data.coversUpToId` marker. When the count reaches `observeAfterTokens`, the observer receives source entries after that marker and may append a non-empty `om.observations.recorded` ledger entry.
 
-Lower values create smaller chunks and more frequent model calls. Higher values reduce model-call frequency but let unobserved raw conversation accumulate longer. If the observer emits no observations, no ledger entry is written and the same range remains eligible for a later observer run.
+Lower values create smaller chunks and more frequent model calls. Higher values reduce model-call frequency but let unobserved raw conversation accumulate longer. If the observer deliberately emits no observations, no ledger entry is written; the same range remains uncovered, and the observer retries after another `observeAfterTokens` of source tokens accumulate.
 
 ## `reflectAfterTokens`
 
@@ -153,7 +153,7 @@ Set `model` when you want the observer, reflector, and dropper to use a cheaper 
 
 Default: `true`.
 
-When `false`, the extension hides routine observer, reflector, and dropper progress notifications. Model fallback/unavailability, no-output warnings, worker failures, compaction notifications, and explicit `/om:*` command output remain visible.
+When `false`, the extension hides routine observer, reflector, and dropper progress notifications (including deliberate-empty observer info messages). Model fallback/unavailability, worker failures (including observer stream errors), compaction notifications, and explicit `/om:*` command output remain visible.
 
 ## `passive`
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -165,15 +165,16 @@ The observer trigger runs on `turn_end`.
 3. Skip if `observerInFlight` is true.
 4. Count raw/source tokens since latest observation coverage.
 5. Skip if below `observeAfterTokens`.
-6. Select source entries after the latest observation coverage marker.
-7. Serialize those source entries for the observer prompt.
-8. Resolve the memory model.
-9. Run `runObserver()` in a background task.
-10. Validate source ids returned by the model.
-11. Compute deterministic 12-character ids and per-observation token counts in code.
-12. Append `om.observations.recorded` only if at least one observation was accepted.
+6. Honor any deliberate-empty backoff until another `observeAfterTokens` of source tokens arrive.
+7. Select the oldest size-capped chunk after the latest observation coverage marker.
+8. Serialize those source entries for the observer prompt.
+9. Resolve the memory model.
+10. Run `runObserver()` in a background task.
+11. Validate source ids returned by the model.
+12. Compute deterministic 12-character ids and per-observation token counts in code.
+13. Append `om.observations.recorded` only if at least one observation was accepted.
 
-If no observations are generated, the worker writes no entry and does not advance coverage. A later eligible observer run will see a larger range.
+If no observations are generated, the worker writes no entry and does not advance coverage. A later eligible observer run will see a larger range. Deliberate empty runs back off until another `observeAfterTokens` worth of new source tokens arrives, so they do not re-fire every turn. Observer chunks target a fixed 60,000 estimated tokens, oldest-first, so an oversized uncovered span drains in slices; the oldest entry is always included even if it alone exceeds the target, preventing coverage from stalling. API/stream failures surface as `observer failed` / `observer.stream_error` rather than as an empty run.
 
 ## Reflect/drop flow
 

--- a/src/agents/dropper/agent.ts
+++ b/src/agents/dropper/agent.ts
@@ -38,7 +38,7 @@ export type { CoverageSummaryByRelevance, CoverageTransitionSummaryByRelevance, 
 
 interface RunDropperArgs {
 	model: Model<any>;
-	apiKey: string;
+	apiKey?: string;
 	headers?: Record<string, string>;
 	reflections: Reflection[];
 	observations: Observation[];

--- a/src/agents/observer/agent.ts
+++ b/src/agents/observer/agent.ts
@@ -12,7 +12,7 @@ import { estimateStringTokens } from "../../tokens.js";
 
 interface RunObserverArgs {
 	model: Model<any>;
-	apiKey: string;
+	apiKey?: string;
 	headers?: Record<string, string>;
 	priorReflections: string[];
 	priorObservations: string[];

--- a/src/agents/observer/agent.ts
+++ b/src/agents/observer/agent.ts
@@ -61,6 +61,21 @@ const RecordObservationsSchema = Type.Object({
 
 type RecordObservationsArgs = Static<typeof RecordObservationsSchema>;
 
+/**
+ * Thrown when the agent loop ends with an API/stream failure (`stopReason`
+ * `"error"`/`"aborted"`) without recording anything. agent-core returns such
+ * runs normally, so without this the caller cannot tell a hard failure from a
+ * deliberate empty result (#32).
+ */
+export class ObserverStreamError extends Error {
+	readonly stopReason: string;
+	constructor(stopReason: string, errorMessage?: string) {
+		super(`observer stream ended with stopReason "${stopReason}"${errorMessage ? `: ${errorMessage}` : ""}`);
+		this.name = "ObserverStreamError";
+		this.stopReason = stopReason;
+	}
+}
+
 function joinOrEmpty(items: string[]): string {
 	return items.length ? items.join("\n") : "(none yet)";
 }
@@ -188,11 +203,21 @@ ${conversation}`;
 
 	const loop = args.agentLoop ?? agentLoop;
 	const stream = loop(prompts, context, config, signal, streamSimple);
-	for await (const _event of stream) {
+	let streamError: { stopReason: string; errorMessage?: string } | undefined;
+	for await (const event of stream) {
 		// Drain events; the tool's execute already collects records.
+		// Watch for a terminal API/stream failure so it is not conflated with
+		// a deliberate empty result.
+		const message = (event as { message?: { role?: string; stopReason?: string; errorMessage?: string } }).message;
+		if (message?.role === "assistant" && (message.stopReason === "error" || message.stopReason === "aborted")) {
+			streamError = { stopReason: message.stopReason, errorMessage: message.errorMessage };
+		}
 	}
 	await stream.result();
 
-	if (accumulated.size === 0) return undefined;
+	if (accumulated.size === 0) {
+		if (streamError) throw new ObserverStreamError(streamError.stopReason, streamError.errorMessage);
+		return undefined;
+	}
 	return Array.from(accumulated.values());
 }

--- a/src/agents/reflector/agent.ts
+++ b/src/agents/reflector/agent.ts
@@ -20,7 +20,7 @@ import {
 
 interface RunReflectorArgs {
 	model: Model<any>;
-	apiKey: string;
+	apiKey?: string;
 	headers?: Record<string, string>;
 	reflections: Reflection[];
 	observations: Observation[];

--- a/src/hooks/consolidation-trigger.ts
+++ b/src/hooks/consolidation-trigger.ts
@@ -1,11 +1,12 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { runDropper } from "../agents/dropper/agent.js";
 import { observationPoolMetrics } from "../agents/dropper/pool.js";
-import { runObserver } from "../agents/observer/agent.js";
+import { ObserverStreamError, runObserver } from "../agents/observer/agent.js";
 import { runReflector } from "../agents/reflector/agent.js";
 import { debugLog, withDebugLogContext } from "../debug-log.js";
 import { type ResolveResult, type Runtime } from "../runtime.js";
 import { serializeSourceAddressedBranchEntries } from "../serialize.js";
+import { estimateEntryTokens } from "../tokens.js";
 import {
 	OM_OBSERVATIONS_DROPPED,
 	OM_OBSERVATIONS_RECORDED,
@@ -24,6 +25,7 @@ import {
 	rawTokensSinceReflectionCoverage,
 	reflectionToSummaryLine,
 	type Entry,
+	type Observation,
 	type Reflection,
 } from "../session-ledger/index.js";
 
@@ -43,6 +45,22 @@ type ConsolidationCtx = {
 };
 
 type StageOutcome = "continue" | "abort";
+
+// ponytail: hardcoded cap, make it a config knob if operators ever need to tune it.
+// Conservative enough that even a heavy chars/4 undercount stays far below real context windows (#32).
+const OBSERVER_CHUNK_MAX_TOKENS = 60_000;
+
+/** Oldest-first prefix of `entries` within `maxTokens`; always keeps the oldest entry so one oversized entry cannot stall coverage. */
+function capChunkOldestFirst(entries: Entry[], maxTokens: number): Entry[] {
+	const capped: Entry[] = [];
+	let total = 0;
+	for (const entry of entries) {
+		if (capped.length > 0 && total + estimateEntryTokens(entry) > maxTokens) break;
+		capped.push(entry);
+		total += estimateEntryTokens(entry);
+	}
+	return capped;
+}
 
 type ReflectorStageResult = {
 	outcome: StageOutcome;
@@ -192,24 +210,58 @@ async function runObserverStage(
 	const tokens = rawTokensSinceObservationCoverage(entries);
 	if (tokens < runtime.config.observeAfterTokens) return "continue";
 
+	const sessionMetadata = debugSessionMetadata(ctx);
+	const sessionIdentity = sessionMetadata.sessionId ?? sessionMetadata.sessionFile;
+	const coverageId = latestCoverageMarkerId(entries, OM_OBSERVATIONS_RECORDED);
+
+	// Deliberate-empty backoff (#23): an intentional "nothing to record" verdict
+	// must not re-fire the observer every turn over the same span. Retry only
+	// after another observeAfterTokens worth of new source tokens arrives, and
+	// drop the backoff as soon as coverage advances.
+	const backoff = runtime.observerEmptyBackoff;
+	if (backoff) {
+		if (
+			sessionIdentity !== backoff.sessionIdentity
+			|| coverageId !== backoff.coverageId
+			|| tokens >= backoff.tokensAtEmpty + runtime.config.observeAfterTokens
+		) {
+			runtime.observerEmptyBackoff = undefined;
+		} else {
+			debugLog("observer.empty_backoff", { tokens, resumeAtTokens: backoff.tokensAtEmpty + runtime.config.observeAfterTokens });
+			return "continue";
+		}
+	}
+
 	const lastCoverageIdx = latestCoverageIndex(entries, OM_OBSERVATIONS_RECORDED);
-	const chunkEntries = sourceEntriesAfter(entries, lastCoverageIdx);
+	const uncoveredEntries = sourceEntriesAfter(entries, lastCoverageIdx);
+	// Cap the chunk (oldest first) so an oversized uncovered span drains in
+	// slices instead of failing permanently once it exceeds the context window (#32).
+	const chunkEntries = capChunkOldestFirst(uncoveredEntries, OBSERVER_CHUNK_MAX_TOKENS);
+	if (chunkEntries.length < uncoveredEntries.length) {
+		debugLog("observer.chunk_capped", {
+			uncoveredEntries: uncoveredEntries.length,
+			chunkEntries: chunkEntries.length,
+			uncoveredTokens: tokens,
+			maxChunkTokens: OBSERVER_CHUNK_MAX_TOKENS,
+		});
+	}
 	const coversUpToId = chunkEntries.at(-1)?.id;
 	if (!coversUpToId) return "continue";
 
 	const { text: chunk, sourceEntryIds } = serializeSourceAddressedBranchEntries(chunkEntries);
 	if (!chunk.trim() || sourceEntryIds.length === 0) return "continue";
 
+	const chunkTokens = chunkEntries.reduce((sum, entry) => sum + estimateEntryTokens(entry), 0);
 	const memory = fullProjection(entries);
 	const priorReflections = memory.reflections.map(reflectionToSummaryLine);
 	const priorObservations = memory.observations.map(observationToSummaryLine);
 
 	if (shouldNotifyWorker(runtime, ctx)) ctx.ui?.notify(
-		`Observational memory: observer running on ~${tokens.toLocaleString()}-token chunk`,
+		`Observational memory: observer running on ~${chunkTokens.toLocaleString()}-token chunk`,
 		"info",
 	);
 	debugLog("observer.start", {
-		tokens,
+		tokens: chunkTokens,
 		coversUpToId,
 		sourceEntryIds,
 		sourceEntryCount: sourceEntryIds.length,
@@ -220,25 +272,42 @@ async function runObserverStage(
 	const resolved = await resolveModel("observer");
 	if (!resolved) return "abort";
 
-	const observations = await runObserver({
-		model: resolved.model as any,
-		apiKey: resolved.apiKey,
-		headers: resolved.headers,
-		priorReflections,
-		priorObservations,
-		chunk,
-		allowedSourceEntryIds: sourceEntryIds,
-		maxTurns: runtime.config.agentMaxTurns,
-		thinkingLevel: runtime.config.model?.thinking ?? "low",
-	});
+	let observations: Observation[] | undefined;
+	try {
+		observations = await runObserver({
+			model: resolved.model as any,
+			apiKey: resolved.apiKey,
+			headers: resolved.headers,
+			priorReflections,
+			priorObservations,
+			chunk,
+			allowedSourceEntryIds: sourceEntryIds,
+			maxTurns: runtime.config.agentMaxTurns,
+			thinkingLevel: runtime.config.model?.thinking ?? "low",
+		});
+	} catch (error) {
+		if (error instanceof ObserverStreamError) {
+			// API/stream failure is not a clean empty (#32): surface it as a real
+			// failure instead of the "no observations" path. Coverage stays put;
+			// the chunk cap keeps the next retry viable.
+			debugLog("observer.stream_error", { coversUpToId, stopReason: error.stopReason, errorMessage: error.message });
+			runtime.recordConsolidationStageError(ctx, "observer", error);
+			return "abort";
+		}
+		throw error;
+	}
 	if (!observations || observations.length === 0) {
+		// Deliberate empty: routine info, not a warning, and back off re-fires
+		// over the same span (#23).
 		debugLog("observer.empty", { coversUpToId });
-		if (ctx.hasUI) ctx.ui?.notify(
-			"Observational memory: observer returned no observations",
-			"warning",
+		runtime.observerEmptyBackoff = { sessionIdentity, coverageId, tokensAtEmpty: tokens };
+		if (shouldNotifyWorker(runtime, ctx)) ctx.ui?.notify(
+			"Observational memory: observer found nothing new in this chunk (coverage unchanged; will retry later)",
+			"info",
 		);
 		return "continue";
 	}
+	runtime.observerEmptyBackoff = undefined;
 
 	const data = buildObservationsRecordedData(observations, coversUpToId);
 	if (!data) return "continue";

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -49,6 +49,12 @@ export class Runtime {
 	lastObserverError: string | undefined;
 	lastReflectorError: string | undefined;
 	lastDropperError: string | undefined;
+	/** Deliberate-empty backoff (#23): skip observer re-fires over the same span until enough new tokens arrive. */
+	observerEmptyBackoff: {
+		sessionIdentity: string | undefined;
+		coverageId: string | undefined;
+		tokensAtEmpty: number;
+	} | undefined;
 
 	ensureConfig(cwd: string): void {
 		if (this.configLoaded) return;

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1,8 +1,25 @@
 import { type Config, DEFAULTS, loadConfig } from "./config.js";
 
 export type ResolveResult =
-	| { ok: true; model: unknown; apiKey: string; headers?: Record<string, string> }
+	| { ok: true; model: unknown; apiKey?: string; headers?: Record<string, string> }
 	| { ok: false; reason: string };
+
+/**
+ * Mirrors pi's own request-auth acceptance rule (`AgentSession._getRequiredRequestAuth`):
+ * resolved auth is usable when it carries an apiKey OR at least one header value.
+ * OAuth providers (kimi-coding, xai, openai-codex, anthropic OAuth, …) authenticate via
+ * `toAuth()` returning `{ headers: { Authorization: "Bearer …" } }` with no apiKey, and
+ * pi-ai providers accept a caller-supplied Authorization header in place of an apiKey.
+ */
+function hasUsableAuth(auth: { apiKey?: unknown; headers?: unknown }): boolean {
+	if (typeof auth.apiKey === "string" && auth.apiKey.length > 0) return true;
+	if (auth.headers && typeof auth.headers === "object") {
+		return Object.values(auth.headers as Record<string, unknown>).some(
+			(value) => typeof value === "string" && value.length > 0,
+		);
+	}
+	return false;
+}
 
 type NotifyLevel = "warning" | "info" | "error";
 type Notify = (message: string, type?: NotifyLevel) => void;
@@ -54,11 +71,15 @@ export class Runtime {
 		}
 		if (!model) return { ok: false, reason: "no model available (session has no model and no observational-memory model configured)" };
 		const auth = await ctx.modelRegistry.getApiKeyAndHeaders(model);
-		if (!auth.ok || !auth.apiKey) {
-			const provider = (model as { provider?: string }).provider ?? "unknown";
-			return { ok: false, reason: `no API key for provider "${provider}"` };
+		const provider = (model as { provider?: string }).provider ?? "unknown";
+		if (!auth.ok || !hasUsableAuth(auth)) {
+			const isOAuth = ctx.modelRegistry.isUsingOAuth?.(model) === true;
+			const reason = isOAuth
+				? `authentication failed for provider "${provider}" — OAuth credentials may have expired; run '/login ${provider}' to re-authenticate`
+				: `no API key or auth headers for provider "${provider}"`;
+			return { ok: false, reason };
 		}
-		return { ok: true, model, apiKey: auth.apiKey as string, headers: auth.headers as Record<string, string> | undefined };
+		return { ok: true, model, apiKey: auth.apiKey as string | undefined, headers: auth.headers as Record<string, string> | undefined };
 	}
 
 	launchConsolidationTask(ctx: LaunchCtx, work: () => Promise<void>): Promise<void> {

--- a/tests/consolidation-trigger.test.ts
+++ b/tests/consolidation-trigger.test.ts
@@ -6,10 +6,14 @@ const mockAgents = vi.hoisted(() => ({
 	runDropper: vi.fn(),
 }));
 
-vi.mock("../src/agents/observer/agent.js", () => ({ runObserver: mockAgents.runObserver }));
+vi.mock("../src/agents/observer/agent.js", async (importOriginal) => ({
+	...(await importOriginal<typeof import("../src/agents/observer/agent.js")>()),
+	runObserver: mockAgents.runObserver,
+}));
 vi.mock("../src/agents/reflector/agent.js", () => ({ runReflector: mockAgents.runReflector }));
 vi.mock("../src/agents/dropper/agent.js", () => ({ runDropper: mockAgents.runDropper }));
 
+import { ObserverStreamError } from "../src/agents/observer/agent.js";
 import { registerConsolidationTrigger } from "../src/hooks/consolidation-trigger.js";
 import {
 	OM_OBSERVATIONS_DROPPED,
@@ -45,8 +49,10 @@ function setup(args: {
 	passive?: boolean;
 	consolidationInFlight?: boolean;
 	appendEntryReturnsId?: boolean;
+	sessionId?: string;
 }) {
 	let entries = [...args.entries];
+	let sessionId = args.sessionId ?? "session-1";
 	const handlers: Record<string, ((event: unknown, ctx: any) => void) | undefined> = {};
 	const pi = {
 		on: vi.fn((eventName: string, cb: (event: unknown, ctx: any) => void) => {
@@ -102,7 +108,10 @@ function setup(args: {
 		ui: { notify: vi.fn() },
 		model: { provider: "session" },
 		modelRegistry: {},
-		sessionManager: { getBranch: () => entries },
+		sessionManager: {
+			getBranch: () => entries,
+			getSessionId: () => sessionId,
+		},
 	};
 	return {
 		pi,
@@ -112,6 +121,12 @@ function setup(args: {
 		fireAgentStart: () => handlers.agent_start!(undefined, ctx),
 		fireTurnEnd: () => handlers.turn_end!(undefined, ctx),
 		runLaunchedWork: async () => launchedWork?.(),
+		addEntries: (...more: TestEntry[]) => {
+			entries = [...entries, ...more];
+		},
+		setSessionId: (next: string) => {
+			sessionId = next;
+		},
 		getEntries: () => entries,
 	};
 }
@@ -299,6 +314,7 @@ describe("V3 consolidation trigger", () => {
 		expect(mockAgents.runDropper).toHaveBeenCalledOnce();
 		expect(quiet.ctx.ui.notify).not.toHaveBeenCalled();
 
+		// Deliberate empty is routine info: also hidden when quiet.
 		mockAgents.runObserver.mockReset();
 		mockAgents.runObserver.mockResolvedValueOnce(undefined);
 		const noOutput = setup({ entries, reflectAfterTokens: 999, showWorkerNotifications: false });
@@ -306,11 +322,133 @@ describe("V3 consolidation trigger", () => {
 		noOutput.fire();
 		await noOutput.runLaunchedWork();
 
-		expect(noOutput.ctx.ui.notify).toHaveBeenCalledOnce();
-		expect(noOutput.ctx.ui.notify).toHaveBeenCalledWith(
-			"Observational memory: observer returned no observations",
+		expect(noOutput.ctx.ui.notify).not.toHaveBeenCalled();
+
+		// Real failures still surface as warnings when quiet.
+		mockAgents.runObserver.mockReset();
+		mockAgents.runObserver.mockRejectedValueOnce(new ObserverStreamError("error", "prompt is too long"));
+		const failed = setup({ entries, reflectAfterTokens: 999, showWorkerNotifications: false });
+
+		failed.fire();
+		await failed.runLaunchedWork();
+
+		expect(failed.ctx.ui.notify).toHaveBeenCalledOnce();
+		expect(failed.ctx.ui.notify.mock.calls[0][1]).toBe("warning");
+		expect(failed.ctx.ui.notify.mock.calls[0][0]).toContain("observer failed");
+	});
+
+	it("reports deliberate empty as info, not a warning", async () => {
+		const entries = [textCustomMessage("raw-1", "aaaaaaaa")];
+		const { fire, runLaunchedWork, ctx } = setup({ entries, reflectAfterTokens: 999 });
+
+		fire();
+		await runLaunchedWork();
+
+		expect(ctx.ui.notify.mock.calls).toEqual([
+			["Observational memory: observer running on ~2-token chunk", "info"],
+			["Observational memory: observer found nothing new in this chunk (coverage unchanged; will retry later)", "info"],
+		]);
+	});
+
+	it("backs off observer re-fires after a deliberate empty until enough new tokens arrive", async () => {
+		const entries = [textCustomMessage("raw-1", "a".repeat(40))]; // 10 tokens
+		const { fire, runLaunchedWork, addEntries, runtime } = setup({ entries, observeAfterTokens: 10, reflectAfterTokens: 999 });
+
+		fire();
+		await runLaunchedWork();
+		expect(mockAgents.runObserver).toHaveBeenCalledTimes(1);
+		expect(runtime.observerEmptyBackoff).toEqual({
+			sessionIdentity: "session-1",
+			coverageId: undefined,
+			tokensAtEmpty: 10,
+		});
+
+		// Same span, only 5 new tokens (< observeAfterTokens more): no re-fire.
+		addEntries(textCustomMessage("raw-2", "b".repeat(20)));
+		runtime.consolidationInFlight = false;
+		fire();
+		expect(runtime.launchConsolidationTask).toHaveBeenCalledTimes(2);
+		await runLaunchedWork();
+		expect(mockAgents.runObserver).toHaveBeenCalledTimes(1);
+
+		// 10 more new tokens: backoff satisfied, observer re-fires over the grown span.
+		addEntries(textCustomMessage("raw-3", "c".repeat(40)));
+		runtime.consolidationInFlight = false;
+		mockAgents.runObserver.mockResolvedValueOnce([obsA]);
+		fire();
+		await runLaunchedWork();
+		expect(mockAgents.runObserver).toHaveBeenCalledTimes(2);
+		expect(runtime.observerEmptyBackoff).toBeUndefined();
+	});
+
+	it("does not apply deliberate-empty backoff to another session", async () => {
+		const entries = [textCustomMessage("raw-1", "a".repeat(40))];
+		const { fire, runLaunchedWork, runtime, setSessionId } = setup({
+			entries,
+			observeAfterTokens: 10,
+			reflectAfterTokens: 999,
+		});
+
+		fire();
+		await runLaunchedWork();
+		expect(mockAgents.runObserver).toHaveBeenCalledTimes(1);
+
+		runtime.consolidationInFlight = false;
+		setSessionId("session-2");
+		fire();
+		await runLaunchedWork();
+
+		expect(mockAgents.runObserver).toHaveBeenCalledTimes(2);
+	});
+
+	it("surfaces API stream errors as observer failure, never as empty", async () => {
+		mockAgents.runObserver.mockRejectedValueOnce(new ObserverStreamError("error", "prompt is too long: 5198507 tokens > 1000000 maximum"));
+		const entries = [textCustomMessage("raw-1", "aaaaaaaa")];
+		const { fire, runLaunchedWork, pi, runtime, ctx } = setup({ entries, reflectAfterTokens: 999 });
+
+		fire();
+		await runLaunchedWork();
+
+		expect(runtime.lastObserverError).toContain("prompt is too long");
+		expect(ctx.ui.notify).toHaveBeenCalledWith(
+			'Observational memory: observer failed: observer stream ended with stopReason "error": prompt is too long: 5198507 tokens > 1000000 maximum',
 			"warning",
 		);
+		expect(ctx.ui.notify).not.toHaveBeenCalledWith(expect.stringContaining("no observations"), expect.anything());
+		expect(pi.appendEntry).not.toHaveBeenCalled();
+		expect(runtime.observerEmptyBackoff).toBeUndefined();
+		expect(mockAgents.runReflector).not.toHaveBeenCalled();
+	});
+
+	it("caps oversized observer chunks oldest-first so coverage advances in slices", async () => {
+		// 3 x 30K-token entries, cap is 60K tokens: only the oldest two make the chunk.
+		const big = "x".repeat(120_000);
+		const entries = [
+			textCustomMessage("raw-1", big),
+			textCustomMessage("raw-2", big),
+			textCustomMessage("raw-3", big),
+		];
+		mockAgents.runObserver.mockResolvedValueOnce([obsA]);
+		const { fire, runLaunchedWork, pi } = setup({ entries, reflectAfterTokens: 999 });
+
+		fire();
+		await runLaunchedWork();
+
+		expect(mockAgents.runObserver).toHaveBeenCalledWith(expect.objectContaining({ allowedSourceEntryIds: ["raw-1", "raw-2"] }));
+		expect(pi.appendEntry).toHaveBeenCalledWith(OM_OBSERVATIONS_RECORDED, { observations: [obsA], coversUpToId: "raw-2" });
+	});
+
+	it("keeps a single entry larger than the chunk cap so coverage cannot stall", async () => {
+		const huge = "x".repeat(400_000); // ~100K tokens, over the 60K cap
+		const entries = [textCustomMessage("raw-1", huge)];
+		mockAgents.runObserver.mockResolvedValueOnce([obsA]);
+		const { fire, runLaunchedWork, pi } = setup({ entries, reflectAfterTokens: 999 });
+
+		fire();
+		await runLaunchedWork();
+
+		expect(mockAgents.runObserver).toHaveBeenCalledWith(expect.objectContaining({ allowedSourceEntryIds: ["raw-1"] }));
+		expect(pi.appendEntry).toHaveBeenCalledWith(OM_OBSERVATIONS_RECORDED, { observations: [obsA], coversUpToId: "raw-1" });
 	});
 
 	it("model resolution failure skips appending and notifies once", async () => {

--- a/tests/consolidation-trigger.test.ts
+++ b/tests/consolidation-trigger.test.ts
@@ -211,6 +211,28 @@ describe("V3 consolidation trigger", () => {
 		expect(pi.appendEntry).toHaveBeenCalledWith(OM_OBSERVATIONS_RECORDED, { observations: [obs], coversUpToId: "raw-1" });
 	});
 
+	it("forwards OAuth-shaped auth (headers, no apiKey) to the observer agent", async () => {
+		const obs = observation("cccccccccccc", { sourceEntryIds: ["raw-1"], tokenCount: 4 });
+		mockAgents.runObserver.mockResolvedValueOnce([obs]);
+		const entries = [textCustomMessage("raw-1", "aaaaaaaa")];
+		const { fire, runLaunchedWork, pi, runtime } = setup({ entries, reflectAfterTokens: 999 });
+		runtime.resolveModel.mockResolvedValueOnce({
+			ok: true,
+			model: { provider: "kimi-coding" },
+			apiKey: undefined,
+			headers: { Authorization: "Bearer oauth-token" },
+		});
+
+		fire();
+		await runLaunchedWork();
+
+		expect(mockAgents.runObserver).toHaveBeenCalledWith(expect.objectContaining({
+			apiKey: undefined,
+			headers: { Authorization: "Bearer oauth-token" },
+		}));
+		expect(pi.appendEntry).toHaveBeenCalledWith(OM_OBSERVATIONS_RECORDED, { observations: [obs], coversUpToId: "raw-1" });
+	});
+
 	it("uses existing observation coverage and retries larger ranges after no-output", async () => {
 		const prior = observation("cccccccccccc", { sourceEntryIds: ["raw-1"] });
 		const newObs = observation("dddddddddddd", { sourceEntryIds: ["raw-2"] });

--- a/tests/oauth-end-to-end.test.ts
+++ b/tests/oauth-end-to-end.test.ts
@@ -1,0 +1,230 @@
+import { createServer, type Server } from "node:http";
+import { AddressInfo } from "node:net";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ModelRegistry } from "@earendil-works/pi-coding-agent";
+
+import { DEFAULTS } from "../src/config.js";
+import { registerConsolidationTrigger } from "../src/hooks/consolidation-trigger.js";
+import { Runtime } from "../src/runtime.js";
+import { OM_OBSERVATIONS_RECORDED } from "../src/session-ledger/index.js";
+import { textCustomMessage } from "./fixtures/session.js";
+
+/**
+ * End-to-end coverage for OAuth-authenticated providers: a headers-only auth
+ * resolution (no apiKey) must flow from pi's real ModelRegistry through
+ * resolveModel into a real observer model request that authenticates with the
+ * caller-supplied Authorization header, and the resulting observations must land
+ * in the session ledger.
+ */
+
+const OAUTH_TOKEN = "Bearer pi-oauth-access-token";
+
+type RecordedRequest = { headers: Record<string, string | undefined>; body: any };
+
+function sse(events: Array<[string, unknown]>): string {
+	return events.map(([event, data]) => `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`).join("");
+}
+
+function toolUseStream(toolInput: unknown): string {
+	return sse([
+		["message_start", {
+			type: "message_start",
+			message: {
+				id: "msg_e2e",
+				type: "message",
+				role: "assistant",
+				model: "om-e2e",
+				content: [],
+				stop_reason: null,
+				stop_sequence: null,
+				usage: { input_tokens: 12, output_tokens: 0 },
+			},
+		}],
+		["content_block_start", {
+			type: "content_block_start",
+			index: 0,
+			content_block: { type: "tool_use", id: "toolu_e2e", name: "record_observations", input: {} },
+		}],
+		["content_block_delta", {
+			type: "content_block_delta",
+			index: 0,
+			delta: { type: "input_json_delta", partial_json: JSON.stringify(toolInput) },
+		}],
+		["content_block_stop", { type: "content_block_stop", index: 0 }],
+		["message_delta", {
+			type: "message_delta",
+			delta: { stop_reason: "tool_use", stop_sequence: null },
+			usage: { output_tokens: 30 },
+		}],
+		["message_stop", { type: "message_stop" }],
+	]);
+}
+
+async function startMockAnthropic(requests: RecordedRequest[]): Promise<{ server: Server; baseUrl: string }> {
+	const server = createServer((req, res) => {
+		const chunks: Buffer[] = [];
+		req.on("data", (chunk) => chunks.push(chunk));
+		req.on("end", () => {
+			const raw = Buffer.concat(chunks).toString("utf8");
+			requests.push({ headers: req.headers as Record<string, string | undefined>, body: raw ? JSON.parse(raw) : undefined });
+			res.writeHead(200, { "content-type": "text/event-stream", "cache-control": "no-cache" });
+			res.end(toolUseStream({
+				observations: [{
+					timestamp: "2026-05-02 10:30",
+					content: "User authenticated with an OAuth provider and asked for memory consolidation.",
+					relevance: "high",
+					sourceEntryIds: ["raw-1"],
+				}],
+			}));
+		});
+	});
+	await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+	const { port } = server.address() as AddressInfo;
+	return { server, baseUrl: `http://127.0.0.1:${port}` };
+}
+
+/**
+ * pi's real ModelRegistry over a minimal ModelRuntime whose provider auth is
+ * OAuth-shaped: no stored apiKey, an Authorization header instead. This is the
+ * `{ ok: true, headers }` (no apiKey) result the real registry hands extensions.
+ */
+function oauthModelRegistry(): any {
+	return new ModelRegistry({
+		getAuth: async () => undefined,
+		getCompatibilityRequestConfig: () => ({ headers: { Authorization: OAUTH_TOKEN }, authHeader: false }),
+		isUsingOAuth: (providerId: string) => providerId === "kimi-coding",
+	} as any);
+}
+
+/** Real ModelRegistry for an OAuth provider whose credentials no longer resolve. */
+function expiredOAuthModelRegistry(provider: string): any {
+	return new ModelRegistry({
+		getAuth: async () => undefined,
+		getCompatibilityRequestConfig: () => ({ headers: undefined, authHeader: true }),
+		isUsingOAuth: (providerId: string) => providerId === provider,
+	} as any);
+}
+
+let activeServer: Server | undefined;
+
+afterEach(async () => {
+	if (activeServer) await new Promise<void>((resolve) => activeServer!.close(() => resolve()));
+	activeServer = undefined;
+});
+
+describe("OAuth provider end-to-end consolidation", () => {
+	it("records observations using headers-only OAuth auth on a real model request", async () => {
+		const requests: RecordedRequest[] = [];
+		const { server, baseUrl } = await startMockAnthropic(requests);
+		activeServer = server;
+
+		const model = {
+			id: "om-e2e",
+			name: "OAuth E2E",
+			api: "anthropic-messages",
+			provider: "kimi-coding",
+			baseUrl,
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 200_000,
+			maxTokens: 8_000,
+		};
+
+		const entries = [textCustomMessage("raw-1", "User: please remember that the OAuth login works.")];
+		const appended: Array<{ customType: string; data: any }> = [];
+		const notices: string[] = [];
+		const handlers: Record<string, ((event: unknown, ctx: any) => void) | undefined> = {};
+		const pi = {
+			on: vi.fn((eventName: string, cb: (event: unknown, ctx: any) => void) => { handlers[eventName] = cb; }),
+			appendEntry: vi.fn((customType: string, data: unknown) => {
+				appended.push({ customType, data });
+				return `appended-${appended.length}`;
+			}),
+		};
+
+		const runtime = new Runtime();
+		runtime.configLoaded = true;
+		runtime.config = { ...DEFAULTS, observeAfterTokens: 1, reflectAfterTokens: 1_000_000, agentMaxTurns: 1 };
+
+		registerConsolidationTrigger(pi as any, runtime);
+
+		handlers.turn_end!(undefined, {
+			cwd: process.cwd(),
+			hasUI: true,
+			ui: { notify: (message: string) => notices.push(message) },
+			model,
+			modelRegistry: oauthModelRegistry(),
+			sessionManager: { getBranch: () => entries },
+		});
+		await runtime.consolidationPromise;
+
+		// The observer really called the provider, authenticating with the OAuth header.
+		expect(requests).toHaveLength(1);
+		expect(requests[0].headers.authorization).toBe(OAUTH_TOKEN);
+		expect(requests[0].headers["x-api-key"]).toBeUndefined();
+
+		// The observation reached the session ledger; nothing was skipped.
+		const recorded = appended.filter((entry) => entry.customType === OM_OBSERVATIONS_RECORDED);
+		expect(recorded).toHaveLength(1);
+		expect(recorded[0].data.observations[0].content).toContain("OAuth provider");
+		expect(recorded[0].data.coversUpToId).toBe("raw-1");
+		expect(notices.filter((message) => message.includes("skipped"))).toEqual([]);
+
+		// eslint-disable-next-line no-console
+		console.log([
+			"",
+			"── OAuth consolidation transcript ─────────────────────────────",
+			`resolved auth        : apiKey=<none> headers.Authorization=${OAUTH_TOKEN}`,
+			`provider request     : POST ${baseUrl}/v1/messages`,
+			`request authorization: ${requests[0].headers.authorization}`,
+			`request x-api-key    : ${requests[0].headers["x-api-key"] ?? "<none>"}`,
+			`ledger entry         : ${recorded[0].customType} coversUpToId=${recorded[0].data.coversUpToId}`,
+			`observation          : ${recorded[0].data.observations[0].content}`,
+			`user notices         : ${notices.join(" | ")}`,
+			"───────────────────────────────────────────────────────────────",
+		].join("\n"));
+	});
+
+	it("tells the user to re-login when OAuth credentials no longer resolve", async () => {
+		const model = { id: "gpt-5-codex", name: "Codex", api: "openai-responses", provider: "openai-codex", contextWindow: 200_000, maxTokens: 8_000 };
+		const entries = [textCustomMessage("raw-1", "User: please remember that the OAuth login works.")];
+		const notices: string[] = [];
+		const appended: unknown[] = [];
+		const handlers: Record<string, ((event: unknown, ctx: any) => void) | undefined> = {};
+		const pi = {
+			on: vi.fn((eventName: string, cb: (event: unknown, ctx: any) => void) => { handlers[eventName] = cb; }),
+			appendEntry: vi.fn((customType: string, data: unknown) => { appended.push({ customType, data }); return "appended-1"; }),
+		};
+
+		const runtime = new Runtime();
+		runtime.configLoaded = true;
+		runtime.config = { ...DEFAULTS, observeAfterTokens: 1, reflectAfterTokens: 1_000_000, agentMaxTurns: 1 };
+
+		registerConsolidationTrigger(pi as any, runtime);
+		handlers.turn_end!(undefined, {
+			cwd: process.cwd(),
+			hasUI: true,
+			ui: { notify: (message: string) => notices.push(message) },
+			model,
+			modelRegistry: expiredOAuthModelRegistry("openai-codex"),
+			sessionManager: { getBranch: () => entries },
+		});
+		await runtime.consolidationPromise;
+
+		const skipped = notices.find((message) => message.includes("skipped"));
+		expect(skipped).toBe(
+			'Observational memory: observer skipped — authentication failed for provider "openai-codex" — OAuth credentials may have expired; run \'/login openai-codex\' to re-authenticate',
+		);
+		expect(appended).toEqual([]);
+
+		// eslint-disable-next-line no-console
+		console.log([
+			"",
+			"── Expired-OAuth user notice ──────────────────────────────────",
+			skipped,
+			"───────────────────────────────────────────────────────────────",
+		].join("\n"));
+	});
+});

--- a/tests/observer.test.ts
+++ b/tests/observer.test.ts
@@ -1,18 +1,22 @@
 import { describe, expect, it } from "vitest";
 
-import { normalizeSourceEntryIds, OBSERVATION_TIMESTAMP_PATTERN, runObserver } from "../src/agents/observer/agent.js";
+import { normalizeSourceEntryIds, OBSERVATION_TIMESTAMP_PATTERN, ObserverStreamError, runObserver } from "../src/agents/observer/agent.js";
 import { estimateStringTokens } from "../src/tokens.js";
 
-function fakeAgentLoop(handler: (prompts: any[], context: any, config: any) => Promise<void> | void): any {
+function fakeAgentLoop(handler: (prompts: any[], context: any, config: any) => Promise<void> | void, events: any[] = []): any {
 	return ((prompts: any[], context: any, config: any) => ({
 		async *[Symbol.asyncIterator]() {
-			// No streaming events needed for these tests.
+			for (const event of events) yield event;
 		},
 		result: async () => {
 			await handler(prompts, context, config);
 			return {};
 		},
 	})) as any;
+}
+
+function assistantEndEvent(stopReason: string, errorMessage?: string): any {
+	return { type: "message_end", message: { role: "assistant", stopReason, errorMessage } };
 }
 
 describe("OBSERVATION_TIMESTAMP_PATTERN", () => {
@@ -105,6 +109,29 @@ describe("runObserver", () => {
 	it("returns undefined when no tool call records observations", async () => {
 		const loop = fakeAgentLoop(() => {});
 		await expect(runObserver({ ...baseArgs, agentLoop: loop })).resolves.toBeUndefined();
+	});
+
+	it("throws ObserverStreamError when the stream errors with nothing recorded", async () => {
+		for (const stopReason of ["error", "aborted"]) {
+			const loop = fakeAgentLoop(() => {}, [assistantEndEvent(stopReason, "prompt is too long")]);
+			const error = await runObserver({ ...baseArgs, agentLoop: loop }).catch((e) => e);
+			expect(error).toBeInstanceOf(ObserverStreamError);
+			expect(error.stopReason).toBe(stopReason);
+			expect(error.message).toContain("prompt is too long");
+		}
+	});
+
+	it("keeps partial observations when the stream errors after recording", async () => {
+		const loop = fakeAgentLoop(async (_prompts, context) => {
+			await context.tools[0].execute("tool-1", {
+				observations: [{ timestamp: "2026-05-02 10:30", content: "Kept despite later error", relevance: "high", sourceEntryIds: ["entry-a"] }],
+			});
+		}, [assistantEndEvent("error", "gateway timeout")]);
+
+		const observations = await runObserver({ ...baseArgs, agentLoop: loop });
+
+		expect(observations).toHaveLength(1);
+		expect(observations?.[0].content).toBe("Kept despite later error");
 	});
 
 	it("uses maxTurns as an observer turn cap", async () => {

--- a/tests/runtime.test.ts
+++ b/tests/runtime.test.ts
@@ -48,7 +48,69 @@ describe("Runtime V3 behavior", () => {
 		const registry = modelRegistry({ auth: { ok: false } });
 		await expect(runtime.resolveModel({ model: { provider: "anthropic" }, modelRegistry: registry, hasUI: false })).resolves.toEqual({
 			ok: false,
-			reason: 'no API key for provider "anthropic"',
+			reason: 'no API key or auth headers for provider "anthropic"',
+		});
+	});
+
+	it("accepts OAuth-shaped auth (headers only, no apiKey)", async () => {
+		const runtime = new Runtime();
+		const model = { provider: "kimi-coding", id: "kimi-for-coding" };
+		const registry = modelRegistry({
+			auth: { ok: true, apiKey: undefined, headers: { Authorization: "Bearer oauth-token" } },
+		});
+
+		const result = await runtime.resolveModel({ model, modelRegistry: registry, hasUI: false });
+
+		expect(result).toEqual({
+			ok: true,
+			model,
+			apiKey: undefined,
+			headers: { Authorization: "Bearer oauth-token" },
+		});
+	});
+
+	it("accepts apiKey auth unchanged", async () => {
+		const runtime = new Runtime();
+		const model = { provider: "anthropic", id: "claude" };
+		const registry = modelRegistry({ auth: { ok: true, apiKey: "sk-ant-key" } });
+
+		const result = await runtime.resolveModel({ model, modelRegistry: registry, hasUI: false });
+
+		expect(result).toEqual({ ok: true, model, apiKey: "sk-ant-key", headers: undefined });
+	});
+
+	it("rejects auth that carries neither apiKey nor usable headers", async () => {
+		const runtime = new Runtime();
+		const model = { provider: "xai" };
+
+		for (const auth of [
+			{ ok: true },
+			{ ok: true, apiKey: "" },
+			{ ok: true, headers: {} },
+			{ ok: true, headers: { Authorization: "" } },
+		]) {
+			const registry = modelRegistry({ auth });
+			await expect(runtime.resolveModel({ model, modelRegistry: registry, hasUI: false })).resolves.toEqual({
+				ok: false,
+				reason: 'no API key or auth headers for provider "xai"',
+			});
+		}
+	});
+
+	it("points OAuth providers at /login when auth resolution fails", async () => {
+		const runtime = new Runtime();
+		const model = { provider: "openai-codex", id: "gpt-5-codex" };
+		const registry = {
+			...modelRegistry({ auth: { ok: false, error: "refresh failed" } }),
+			isUsingOAuth: vi.fn((candidate: { provider?: string }) => candidate?.provider === "openai-codex"),
+		};
+
+		const result = await runtime.resolveModel({ model, modelRegistry: registry, hasUI: false });
+
+		expect(registry.isUsingOAuth).toHaveBeenCalledWith(model);
+		expect(result).toEqual({
+			ok: false,
+			reason: 'authentication failed for provider "openai-codex" — OAuth credentials may have expired; run \'/login openai-codex\' to re-authenticate',
 		});
 	});
 


### PR DESCRIPTION
## Summary

Allow Observational Memory to compact and consolidate with Pi providers authenticated through OAuth headers rather than a literal API key.

Fixes #37.

## Problem

`Runtime.resolveModel()` rejected resolved authentication unless it contained `auth.apiKey`. That aborts compaction for OAuth-authenticated providers such as `kimi-coding`, `xai`, `openai-codex`, and Anthropic OAuth even though the active Pi session works normally.

Those providers' `toAuth()` implementations return usable request headers, for example:

```ts
{ headers: { Authorization: "Bearer …" } }
```

Pi's own session request path accepts either an API key or usable headers, so Observational Memory was applying a stricter auth rule than Pi itself.

## Changes

- Accept resolved auth when it has either a non-empty API key or at least one non-empty header value.
- Keep API-key behavior unchanged.
- Preserve clear failure behavior when neither auth form is usable.
- Pass the model through OAuth detection so recovery guidance can direct OAuth users to login rather than asking for an API key.
- Document OAuth-header auth for memory workers.
- Add regression coverage for headers-only OAuth auth, API-key auth, missing auth, and the compaction/consolidation path.

## Validation

- Merged current upstream `master` and resolved conflicts.
- `npm run typecheck`
- `npm test` (**227/227 passing**)

## Compatibility

This is additive: providers that resolve a literal API key follow the existing path unchanged. Only auth shapes that Pi already considers usable are newly accepted.
