### PR TITLE
fix(observer): distinguish stream failures and back off deliberate empties

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ Valid `model.thinking` values are:
 
 If no `model` is configured, memory workers use the session model.
 
-Set `showWorkerNotifications` to `false` to hide routine worker start and completion messages. Model fallback/unavailability, no-output warnings, worker failures, compaction notifications, and explicit `/om:*` command output remain visible.
+Set `showWorkerNotifications` to `false` to hide routine worker start and completion messages (including deliberate-empty observer info messages). Model fallback/unavailability, worker failures (including observer stream errors), compaction notifications, and explicit `/om:*` command output remain visible.
 
 `observationsPoolMaxTokens` and `observationsPoolTargetTokens` intentionally describe different pools. Max tokens control when compaction performs a full fold over visible memory. Target tokens control the folded active observation pool that the dropper maintains after successful reflection. If the target is omitted, it defaults to half of max.
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -70,9 +70,9 @@ Dropping does not delete history. Dropped observations remain recallable from le
 
 ### Observer
 
-The observer runs asynchronously from `turn_end` when raw/source tokens after the latest observation coverage marker reach `observeAfterTokens`.
+The observer runs asynchronously from `turn_end` when raw/source tokens after the latest observation coverage marker reach `observeAfterTokens`. After a deliberate empty result, it waits for another `observeAfterTokens` of source tokens before retrying the uncovered range.
 
-It receives raw/source entries only, validates source ids, and appends a non-empty `om.observations.recorded` entry. If there is nothing worth recording, it writes no entry and the raw range remains eligible for a later observer run.
+It receives an oldest-first chunk of raw/source entries, validates source ids, and appends a non-empty `om.observations.recorded` entry. Chunking targets a fixed 60,000 estimated tokens but always includes at least one entry, so a single oversized entry cannot stall coverage. If there is nothing worth recording, it writes no entry and leaves the raw range uncovered.
 
 ### Reflector
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -77,7 +77,7 @@ Default: `10000`.
 
 The observer runs from Pi's `turn_end` hook. It counts raw/source tokens after the latest `om.observations.recorded.data.coversUpToId` marker. When the count reaches `observeAfterTokens`, the observer receives source entries after that marker and may append a non-empty `om.observations.recorded` ledger entry.
 
-Lower values create smaller chunks and more frequent model calls. Higher values reduce model-call frequency but let unobserved raw conversation accumulate longer. If the observer emits no observations, no ledger entry is written and the same range remains eligible for a later observer run.
+Lower values create smaller chunks and more frequent model calls. Higher values reduce model-call frequency but let unobserved raw conversation accumulate longer. If the observer deliberately emits no observations, no ledger entry is written; the same range remains uncovered, and the observer retries after another `observeAfterTokens` of source tokens accumulate.
 
 ## `reflectAfterTokens`
 
@@ -153,7 +153,7 @@ Set `model` when you want the observer, reflector, and dropper to use a cheaper 
 
 Default: `true`.
 
-When `false`, the extension hides routine observer, reflector, and dropper progress notifications. Model fallback/unavailability, no-output warnings, worker failures, compaction notifications, and explicit `/om:*` command output remain visible.
+When `false`, the extension hides routine observer, reflector, and dropper progress notifications (including deliberate-empty observer info messages). Model fallback/unavailability, worker failures (including observer stream errors), compaction notifications, and explicit `/om:*` command output remain visible.
 
 ## `passive`
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -165,15 +165,16 @@ The observer trigger runs on `turn_end`.
 3. Skip if `observerInFlight` is true.
 4. Count raw/source tokens since latest observation coverage.
 5. Skip if below `observeAfterTokens`.
-6. Select source entries after the latest observation coverage marker.
-7. Serialize those source entries for the observer prompt.
-8. Resolve the memory model.
-9. Run `runObserver()` in a background task.
-10. Validate source ids returned by the model.
-11. Compute deterministic 12-character ids and per-observation token counts in code.
-12. Append `om.observations.recorded` only if at least one observation was accepted.
+6. Honor any deliberate-empty backoff until another `observeAfterTokens` of source tokens arrive.
+7. Select the oldest size-capped chunk after the latest observation coverage marker.
+8. Serialize those source entries for the observer prompt.
+9. Resolve the memory model.
+10. Run `runObserver()` in a background task.
+11. Validate source ids returned by the model.
+12. Compute deterministic 12-character ids and per-observation token counts in code.
+13. Append `om.observations.recorded` only if at least one observation was accepted.
 
-If no observations are generated, the worker writes no entry and does not advance coverage. A later eligible observer run will see a larger range.
+If no observations are generated, the worker writes no entry and does not advance coverage. A later eligible observer run will see a larger range. Deliberate empty runs back off until another `observeAfterTokens` worth of new source tokens arrives, so they do not re-fire every turn. Observer chunks target a fixed 60,000 estimated tokens, oldest-first, so an oversized uncovered span drains in slices; the oldest entry is always included even if it alone exceeds the target, preventing coverage from stalling. API/stream failures surface as `observer failed` / `observer.stream_error` rather than as an empty run.
 
 ## Reflect/drop flow
 

--- a/src/agents/observer/agent.ts
+++ b/src/agents/observer/agent.ts
@@ -61,6 +61,21 @@ const RecordObservationsSchema = Type.Object({
 
 type RecordObservationsArgs = Static<typeof RecordObservationsSchema>;
 
+/**
+ * Thrown when the agent loop ends with an API/stream failure (`stopReason`
+ * `"error"`/`"aborted"`) without recording anything. agent-core returns such
+ * runs normally, so without this the caller cannot tell a hard failure from a
+ * deliberate empty result (#32).
+ */
+export class ObserverStreamError extends Error {
+	readonly stopReason: string;
+	constructor(stopReason: string, errorMessage?: string) {
+		super(`observer stream ended with stopReason "${stopReason}"${errorMessage ? `: ${errorMessage}` : ""}`);
+		this.name = "ObserverStreamError";
+		this.stopReason = stopReason;
+	}
+}
+
 function joinOrEmpty(items: string[]): string {
 	return items.length ? items.join("\n") : "(none yet)";
 }
@@ -188,11 +203,21 @@ ${conversation}`;
 
 	const loop = args.agentLoop ?? agentLoop;
 	const stream = loop(prompts, context, config, signal, streamSimple);
-	for await (const _event of stream) {
+	let streamError: { stopReason: string; errorMessage?: string } | undefined;
+	for await (const event of stream) {
 		// Drain events; the tool's execute already collects records.
+		// Watch for a terminal API/stream failure so it is not conflated with
+		// a deliberate empty result.
+		const message = (event as { message?: { role?: string; stopReason?: string; errorMessage?: string } }).message;
+		if (message?.role === "assistant" && (message.stopReason === "error" || message.stopReason === "aborted")) {
+			streamError = { stopReason: message.stopReason, errorMessage: message.errorMessage };
+		}
 	}
 	await stream.result();
 
-	if (accumulated.size === 0) return undefined;
+	if (accumulated.size === 0) {
+		if (streamError) throw new ObserverStreamError(streamError.stopReason, streamError.errorMessage);
+		return undefined;
+	}
 	return Array.from(accumulated.values());
 }

--- a/src/hooks/consolidation-trigger.ts
+++ b/src/hooks/consolidation-trigger.ts
@@ -1,11 +1,12 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { runDropper } from "../agents/dropper/agent.js";
 import { observationPoolMetrics } from "../agents/dropper/pool.js";
-import { runObserver } from "../agents/observer/agent.js";
+import { ObserverStreamError, runObserver } from "../agents/observer/agent.js";
 import { runReflector } from "../agents/reflector/agent.js";
 import { debugLog, withDebugLogContext } from "../debug-log.js";
 import { type ResolveResult, type Runtime } from "../runtime.js";
 import { serializeSourceAddressedBranchEntries } from "../serialize.js";
+import { estimateEntryTokens } from "../tokens.js";
 import {
 	OM_OBSERVATIONS_DROPPED,
 	OM_OBSERVATIONS_RECORDED,
@@ -24,6 +25,7 @@ import {
 	rawTokensSinceReflectionCoverage,
 	reflectionToSummaryLine,
 	type Entry,
+	type Observation,
 	type Reflection,
 } from "../session-ledger/index.js";
 
@@ -43,6 +45,22 @@ type ConsolidationCtx = {
 };
 
 type StageOutcome = "continue" | "abort";
+
+// ponytail: hardcoded cap, make it a config knob if operators ever need to tune it.
+// Conservative enough that even a heavy chars/4 undercount stays far below real context windows (#32).
+const OBSERVER_CHUNK_MAX_TOKENS = 60_000;
+
+/** Oldest-first prefix of `entries` within `maxTokens`; always keeps the oldest entry so one oversized entry cannot stall coverage. */
+function capChunkOldestFirst(entries: Entry[], maxTokens: number): Entry[] {
+	const capped: Entry[] = [];
+	let total = 0;
+	for (const entry of entries) {
+		if (capped.length > 0 && total + estimateEntryTokens(entry) > maxTokens) break;
+		capped.push(entry);
+		total += estimateEntryTokens(entry);
+	}
+	return capped;
+}
 
 type ReflectorStageResult = {
 	outcome: StageOutcome;
@@ -192,24 +210,58 @@ async function runObserverStage(
 	const tokens = rawTokensSinceObservationCoverage(entries);
 	if (tokens < runtime.config.observeAfterTokens) return "continue";
 
+	const sessionMetadata = debugSessionMetadata(ctx);
+	const sessionIdentity = sessionMetadata.sessionId ?? sessionMetadata.sessionFile;
+	const coverageId = latestCoverageMarkerId(entries, OM_OBSERVATIONS_RECORDED);
+
+	// Deliberate-empty backoff (#23): an intentional "nothing to record" verdict
+	// must not re-fire the observer every turn over the same span. Retry only
+	// after another observeAfterTokens worth of new source tokens arrives, and
+	// drop the backoff as soon as coverage advances.
+	const backoff = runtime.observerEmptyBackoff;
+	if (backoff) {
+		if (
+			sessionIdentity !== backoff.sessionIdentity
+			|| coverageId !== backoff.coverageId
+			|| tokens >= backoff.tokensAtEmpty + runtime.config.observeAfterTokens
+		) {
+			runtime.observerEmptyBackoff = undefined;
+		} else {
+			debugLog("observer.empty_backoff", { tokens, resumeAtTokens: backoff.tokensAtEmpty + runtime.config.observeAfterTokens });
+			return "continue";
+		}
+	}
+
 	const lastCoverageIdx = latestCoverageIndex(entries, OM_OBSERVATIONS_RECORDED);
-	const chunkEntries = sourceEntriesAfter(entries, lastCoverageIdx);
+	const uncoveredEntries = sourceEntriesAfter(entries, lastCoverageIdx);
+	// Cap the chunk (oldest first) so an oversized uncovered span drains in
+	// slices instead of failing permanently once it exceeds the context window (#32).
+	const chunkEntries = capChunkOldestFirst(uncoveredEntries, OBSERVER_CHUNK_MAX_TOKENS);
+	if (chunkEntries.length < uncoveredEntries.length) {
+		debugLog("observer.chunk_capped", {
+			uncoveredEntries: uncoveredEntries.length,
+			chunkEntries: chunkEntries.length,
+			uncoveredTokens: tokens,
+			maxChunkTokens: OBSERVER_CHUNK_MAX_TOKENS,
+		});
+	}
 	const coversUpToId = chunkEntries.at(-1)?.id;
 	if (!coversUpToId) return "continue";
 
 	const { text: chunk, sourceEntryIds } = serializeSourceAddressedBranchEntries(chunkEntries);
 	if (!chunk.trim() || sourceEntryIds.length === 0) return "continue";
 
+	const chunkTokens = chunkEntries.reduce((sum, entry) => sum + estimateEntryTokens(entry), 0);
 	const memory = fullProjection(entries);
 	const priorReflections = memory.reflections.map(reflectionToSummaryLine);
 	const priorObservations = memory.observations.map(observationToSummaryLine);
 
 	if (shouldNotifyWorker(runtime, ctx)) ctx.ui?.notify(
-		`Observational memory: observer running on ~${tokens.toLocaleString()}-token chunk`,
+		`Observational memory: observer running on ~${chunkTokens.toLocaleString()}-token chunk`,
 		"info",
 	);
 	debugLog("observer.start", {
-		tokens,
+		tokens: chunkTokens,
 		coversUpToId,
 		sourceEntryIds,
 		sourceEntryCount: sourceEntryIds.length,
@@ -220,25 +272,42 @@ async function runObserverStage(
 	const resolved = await resolveModel("observer");
 	if (!resolved) return "abort";
 
-	const observations = await runObserver({
-		model: resolved.model as any,
-		apiKey: resolved.apiKey,
-		headers: resolved.headers,
-		priorReflections,
-		priorObservations,
-		chunk,
-		allowedSourceEntryIds: sourceEntryIds,
-		maxTurns: runtime.config.agentMaxTurns,
-		thinkingLevel: runtime.config.model?.thinking ?? "low",
-	});
+	let observations: Observation[] | undefined;
+	try {
+		observations = await runObserver({
+			model: resolved.model as any,
+			apiKey: resolved.apiKey,
+			headers: resolved.headers,
+			priorReflections,
+			priorObservations,
+			chunk,
+			allowedSourceEntryIds: sourceEntryIds,
+			maxTurns: runtime.config.agentMaxTurns,
+			thinkingLevel: runtime.config.model?.thinking ?? "low",
+		});
+	} catch (error) {
+		if (error instanceof ObserverStreamError) {
+			// API/stream failure is not a clean empty (#32): surface it as a real
+			// failure instead of the "no observations" path. Coverage stays put;
+			// the chunk cap keeps the next retry viable.
+			debugLog("observer.stream_error", { coversUpToId, stopReason: error.stopReason, errorMessage: error.message });
+			runtime.recordConsolidationStageError(ctx, "observer", error);
+			return "abort";
+		}
+		throw error;
+	}
 	if (!observations || observations.length === 0) {
+		// Deliberate empty: routine info, not a warning, and back off re-fires
+		// over the same span (#23).
 		debugLog("observer.empty", { coversUpToId });
-		if (ctx.hasUI) ctx.ui?.notify(
-			"Observational memory: observer returned no observations",
-			"warning",
+		runtime.observerEmptyBackoff = { sessionIdentity, coverageId, tokensAtEmpty: tokens };
+		if (shouldNotifyWorker(runtime, ctx)) ctx.ui?.notify(
+			"Observational memory: observer found nothing new in this chunk (coverage unchanged; will retry later)",
+			"info",
 		);
 		return "continue";
 	}
+	runtime.observerEmptyBackoff = undefined;
 
 	const data = buildObservationsRecordedData(observations, coversUpToId);
 	if (!data) return "continue";

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -32,6 +32,12 @@ export class Runtime {
 	lastObserverError: string | undefined;
 	lastReflectorError: string | undefined;
 	lastDropperError: string | undefined;
+	/** Deliberate-empty backoff (#23): skip observer re-fires over the same span until enough new tokens arrive. */
+	observerEmptyBackoff: {
+		sessionIdentity: string | undefined;
+		coverageId: string | undefined;
+		tokensAtEmpty: number;
+	} | undefined;
 
 	ensureConfig(cwd: string): void {
 		if (this.configLoaded) return;

--- a/tests/consolidation-trigger.test.ts
+++ b/tests/consolidation-trigger.test.ts
@@ -6,10 +6,14 @@ const mockAgents = vi.hoisted(() => ({
 	runDropper: vi.fn(),
 }));
 
-vi.mock("../src/agents/observer/agent.js", () => ({ runObserver: mockAgents.runObserver }));
+vi.mock("../src/agents/observer/agent.js", async (importOriginal) => ({
+	...(await importOriginal<typeof import("../src/agents/observer/agent.js")>()),
+	runObserver: mockAgents.runObserver,
+}));
 vi.mock("../src/agents/reflector/agent.js", () => ({ runReflector: mockAgents.runReflector }));
 vi.mock("../src/agents/dropper/agent.js", () => ({ runDropper: mockAgents.runDropper }));
 
+import { ObserverStreamError } from "../src/agents/observer/agent.js";
 import { registerConsolidationTrigger } from "../src/hooks/consolidation-trigger.js";
 import {
 	OM_OBSERVATIONS_DROPPED,
@@ -45,8 +49,10 @@ function setup(args: {
 	passive?: boolean;
 	consolidationInFlight?: boolean;
 	appendEntryReturnsId?: boolean;
+	sessionId?: string;
 }) {
 	let entries = [...args.entries];
+	let sessionId = args.sessionId ?? "session-1";
 	const handlers: Record<string, ((event: unknown, ctx: any) => void) | undefined> = {};
 	const pi = {
 		on: vi.fn((eventName: string, cb: (event: unknown, ctx: any) => void) => {
@@ -102,7 +108,10 @@ function setup(args: {
 		ui: { notify: vi.fn() },
 		model: { provider: "session" },
 		modelRegistry: {},
-		sessionManager: { getBranch: () => entries },
+		sessionManager: {
+			getBranch: () => entries,
+			getSessionId: () => sessionId,
+		},
 	};
 	return {
 		pi,
@@ -112,6 +121,12 @@ function setup(args: {
 		fireAgentStart: () => handlers.agent_start!(undefined, ctx),
 		fireTurnEnd: () => handlers.turn_end!(undefined, ctx),
 		runLaunchedWork: async () => launchedWork?.(),
+		addEntries: (...more: TestEntry[]) => {
+			entries = [...entries, ...more];
+		},
+		setSessionId: (next: string) => {
+			sessionId = next;
+		},
 		getEntries: () => entries,
 	};
 }
@@ -277,6 +292,7 @@ describe("V3 consolidation trigger", () => {
 		expect(mockAgents.runDropper).toHaveBeenCalledOnce();
 		expect(quiet.ctx.ui.notify).not.toHaveBeenCalled();
 
+		// Deliberate empty is routine info: also hidden when quiet.
 		mockAgents.runObserver.mockReset();
 		mockAgents.runObserver.mockResolvedValueOnce(undefined);
 		const noOutput = setup({ entries, reflectAfterTokens: 999, showWorkerNotifications: false });
@@ -284,11 +300,133 @@ describe("V3 consolidation trigger", () => {
 		noOutput.fire();
 		await noOutput.runLaunchedWork();
 
-		expect(noOutput.ctx.ui.notify).toHaveBeenCalledOnce();
-		expect(noOutput.ctx.ui.notify).toHaveBeenCalledWith(
-			"Observational memory: observer returned no observations",
+		expect(noOutput.ctx.ui.notify).not.toHaveBeenCalled();
+
+		// Real failures still surface as warnings when quiet.
+		mockAgents.runObserver.mockReset();
+		mockAgents.runObserver.mockRejectedValueOnce(new ObserverStreamError("error", "prompt is too long"));
+		const failed = setup({ entries, reflectAfterTokens: 999, showWorkerNotifications: false });
+
+		failed.fire();
+		await failed.runLaunchedWork();
+
+		expect(failed.ctx.ui.notify).toHaveBeenCalledOnce();
+		expect(failed.ctx.ui.notify.mock.calls[0][1]).toBe("warning");
+		expect(failed.ctx.ui.notify.mock.calls[0][0]).toContain("observer failed");
+	});
+
+	it("reports deliberate empty as info, not a warning", async () => {
+		const entries = [textCustomMessage("raw-1", "aaaaaaaa")];
+		const { fire, runLaunchedWork, ctx } = setup({ entries, reflectAfterTokens: 999 });
+
+		fire();
+		await runLaunchedWork();
+
+		expect(ctx.ui.notify.mock.calls).toEqual([
+			["Observational memory: observer running on ~2-token chunk", "info"],
+			["Observational memory: observer found nothing new in this chunk (coverage unchanged; will retry later)", "info"],
+		]);
+	});
+
+	it("backs off observer re-fires after a deliberate empty until enough new tokens arrive", async () => {
+		const entries = [textCustomMessage("raw-1", "a".repeat(40))]; // 10 tokens
+		const { fire, runLaunchedWork, addEntries, runtime } = setup({ entries, observeAfterTokens: 10, reflectAfterTokens: 999 });
+
+		fire();
+		await runLaunchedWork();
+		expect(mockAgents.runObserver).toHaveBeenCalledTimes(1);
+		expect(runtime.observerEmptyBackoff).toEqual({
+			sessionIdentity: "session-1",
+			coverageId: undefined,
+			tokensAtEmpty: 10,
+		});
+
+		// Same span, only 5 new tokens (< observeAfterTokens more): no re-fire.
+		addEntries(textCustomMessage("raw-2", "b".repeat(20)));
+		runtime.consolidationInFlight = false;
+		fire();
+		expect(runtime.launchConsolidationTask).toHaveBeenCalledTimes(2);
+		await runLaunchedWork();
+		expect(mockAgents.runObserver).toHaveBeenCalledTimes(1);
+
+		// 10 more new tokens: backoff satisfied, observer re-fires over the grown span.
+		addEntries(textCustomMessage("raw-3", "c".repeat(40)));
+		runtime.consolidationInFlight = false;
+		mockAgents.runObserver.mockResolvedValueOnce([obsA]);
+		fire();
+		await runLaunchedWork();
+		expect(mockAgents.runObserver).toHaveBeenCalledTimes(2);
+		expect(runtime.observerEmptyBackoff).toBeUndefined();
+	});
+
+	it("does not apply deliberate-empty backoff to another session", async () => {
+		const entries = [textCustomMessage("raw-1", "a".repeat(40))];
+		const { fire, runLaunchedWork, runtime, setSessionId } = setup({
+			entries,
+			observeAfterTokens: 10,
+			reflectAfterTokens: 999,
+		});
+
+		fire();
+		await runLaunchedWork();
+		expect(mockAgents.runObserver).toHaveBeenCalledTimes(1);
+
+		runtime.consolidationInFlight = false;
+		setSessionId("session-2");
+		fire();
+		await runLaunchedWork();
+
+		expect(mockAgents.runObserver).toHaveBeenCalledTimes(2);
+	});
+
+	it("surfaces API stream errors as observer failure, never as empty", async () => {
+		mockAgents.runObserver.mockRejectedValueOnce(new ObserverStreamError("error", "prompt is too long: 5198507 tokens > 1000000 maximum"));
+		const entries = [textCustomMessage("raw-1", "aaaaaaaa")];
+		const { fire, runLaunchedWork, pi, runtime, ctx } = setup({ entries, reflectAfterTokens: 999 });
+
+		fire();
+		await runLaunchedWork();
+
+		expect(runtime.lastObserverError).toContain("prompt is too long");
+		expect(ctx.ui.notify).toHaveBeenCalledWith(
+			'Observational memory: observer failed: observer stream ended with stopReason "error": prompt is too long: 5198507 tokens > 1000000 maximum',
 			"warning",
 		);
+		expect(ctx.ui.notify).not.toHaveBeenCalledWith(expect.stringContaining("no observations"), expect.anything());
+		expect(pi.appendEntry).not.toHaveBeenCalled();
+		expect(runtime.observerEmptyBackoff).toBeUndefined();
+		expect(mockAgents.runReflector).not.toHaveBeenCalled();
+	});
+
+	it("caps oversized observer chunks oldest-first so coverage advances in slices", async () => {
+		// 3 x 30K-token entries, cap is 60K tokens: only the oldest two make the chunk.
+		const big = "x".repeat(120_000);
+		const entries = [
+			textCustomMessage("raw-1", big),
+			textCustomMessage("raw-2", big),
+			textCustomMessage("raw-3", big),
+		];
+		mockAgents.runObserver.mockResolvedValueOnce([obsA]);
+		const { fire, runLaunchedWork, pi } = setup({ entries, reflectAfterTokens: 999 });
+
+		fire();
+		await runLaunchedWork();
+
+		expect(mockAgents.runObserver).toHaveBeenCalledWith(expect.objectContaining({ allowedSourceEntryIds: ["raw-1", "raw-2"] }));
+		expect(pi.appendEntry).toHaveBeenCalledWith(OM_OBSERVATIONS_RECORDED, { observations: [obsA], coversUpToId: "raw-2" });
+	});
+
+	it("keeps a single entry larger than the chunk cap so coverage cannot stall", async () => {
+		const huge = "x".repeat(400_000); // ~100K tokens, over the 60K cap
+		const entries = [textCustomMessage("raw-1", huge)];
+		mockAgents.runObserver.mockResolvedValueOnce([obsA]);
+		const { fire, runLaunchedWork, pi } = setup({ entries, reflectAfterTokens: 999 });
+
+		fire();
+		await runLaunchedWork();
+
+		expect(mockAgents.runObserver).toHaveBeenCalledWith(expect.objectContaining({ allowedSourceEntryIds: ["raw-1"] }));
+		expect(pi.appendEntry).toHaveBeenCalledWith(OM_OBSERVATIONS_RECORDED, { observations: [obsA], coversUpToId: "raw-1" });
 	});
 
 	it("model resolution failure skips appending and notifies once", async () => {

--- a/tests/observer.test.ts
+++ b/tests/observer.test.ts
@@ -1,18 +1,22 @@
 import { describe, expect, it } from "vitest";
 
-import { normalizeSourceEntryIds, OBSERVATION_TIMESTAMP_PATTERN, runObserver } from "../src/agents/observer/agent.js";
+import { normalizeSourceEntryIds, OBSERVATION_TIMESTAMP_PATTERN, ObserverStreamError, runObserver } from "../src/agents/observer/agent.js";
 import { estimateStringTokens } from "../src/tokens.js";
 
-function fakeAgentLoop(handler: (prompts: any[], context: any, config: any) => Promise<void> | void): any {
+function fakeAgentLoop(handler: (prompts: any[], context: any, config: any) => Promise<void> | void, events: any[] = []): any {
 	return ((prompts: any[], context: any, config: any) => ({
 		async *[Symbol.asyncIterator]() {
-			// No streaming events needed for these tests.
+			for (const event of events) yield event;
 		},
 		result: async () => {
 			await handler(prompts, context, config);
 			return {};
 		},
 	})) as any;
+}
+
+function assistantEndEvent(stopReason: string, errorMessage?: string): any {
+	return { type: "message_end", message: { role: "assistant", stopReason, errorMessage } };
 }
 
 describe("OBSERVATION_TIMESTAMP_PATTERN", () => {
@@ -105,6 +109,29 @@ describe("runObserver", () => {
 	it("returns undefined when no tool call records observations", async () => {
 		const loop = fakeAgentLoop(() => {});
 		await expect(runObserver({ ...baseArgs, agentLoop: loop })).resolves.toBeUndefined();
+	});
+
+	it("throws ObserverStreamError when the stream errors with nothing recorded", async () => {
+		for (const stopReason of ["error", "aborted"]) {
+			const loop = fakeAgentLoop(() => {}, [assistantEndEvent(stopReason, "prompt is too long")]);
+			const error = await runObserver({ ...baseArgs, agentLoop: loop }).catch((e) => e);
+			expect(error).toBeInstanceOf(ObserverStreamError);
+			expect(error.stopReason).toBe(stopReason);
+			expect(error.message).toContain("prompt is too long");
+		}
+	});
+
+	it("keeps partial observations when the stream errors after recording", async () => {
+		const loop = fakeAgentLoop(async (_prompts, context) => {
+			await context.tools[0].execute("tool-1", {
+				observations: [{ timestamp: "2026-05-02 10:30", content: "Kept despite later error", relevance: "high", sourceEntryIds: ["entry-a"] }],
+			});
+		}, [assistantEndEvent("error", "gateway timeout")]);
+
+		const observations = await runObserver({ ...baseArgs, agentLoop: loop });
+
+		expect(observations).toHaveLength(1);
+		expect(observations?.[0].content).toBe("Kept despite later error");
 	});
 
 	it("uses maxTurns as an observer turn cap", async () => {


### PR DESCRIPTION
## Summary

Updated after upstream merged #33 and #34.

This branch is intentionally slim: it keeps #33's debug stream-error logging and #34's context-window-derived observer chunk cap. It only fills the operator-facing gaps those PRs leave open.

Fixes #32. Fixes #23.

## Gap after #33: stream errors are logged but still look like empty observer results

#33 adds `logAgentStreamError(...)` so terminal LLM stream events with `stopReason: error|aborted` are written to the debug log for observer/reflector/dropper runs.

The remaining gap is that the observer still returns `undefined` when that terminal stream failure produced zero observations. Consolidation therefore cannot tell the difference between:

- a real provider/API/stream failure, and
- a deliberate “nothing new to record” observer result.

This PR fills that gap by:

- tracking terminal observer stream failures while still using #33's debug logging;
- throwing `ObserverStreamError` only when the run ended in `error|aborted` **and** recorded nothing;
- reporting that as `observer failed: ...` through consolidation so operators see the provider error instead of a fake empty result;
- preserving partial observations when any were recorded before a trailing stream error.

## Gap after #34: oversized chunks are fixed, but deliberate empties still re-fire and warn

#34 fixes the chunking problem better than this branch originally did: the observer chunk cap is derived from the resolved model context window, configurable via `observerChunkMaxTokens`, with a 60k fallback and oversized-entry excerpt handling.

The remaining gap is what happens after a valid observer run deliberately finds nothing worth recording. Because coverage is unchanged, upstream can keep re-running the observer over the same unchanged span on later triggers, and it reports that normal empty result as a warning.

This PR fills that gap by:

- storing a session-scoped deliberate-empty backoff keyed by session identity, coverage marker, and token count;
- skipping re-runs over the same span until another `observeAfterTokens` worth of source text arrives;
- clearing the backoff when coverage advances or the session changes;
- reporting deliberate empty as routine `info`: `found nothing new ... will retry later`.

## What this PR no longer claims

- It does **not** reintroduce the original hardcoded 60k chunk cap. #34's implementation is kept.
- It does **not** replace #33's debug logging. It builds the observer failure classification on top of it.

## Test plan

- [x] `npm run typecheck`
- [x] `npm test` (**220/220 passing**)
