### PR TITLE
fix: preserve context when memory is empty

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+      - run: npm run typecheck
+      - run: npm test

--- a/README.md
+++ b/README.md
@@ -173,6 +173,8 @@ This extension is especially useful when the session contains decisions that sho
 
 ## Install
 
+Requires Pi 0.81.0 or newer. Proactive compaction uses the `agent_settled` lifecycle event introduced in that release.
+
 ```bash
 pi install npm:pi-observational-memory
 ```
@@ -325,14 +327,14 @@ flowchart TD
     Turn[turn_end]
     Observe[Capture observations]
     Reflect[Distill reflections]
-    AgentEnd[agent_end]
+    AgentSettled[agent_settled]
     Trigger[auto-compaction trigger]
     Compact[session_before_compact]
     Summary[visible memory for Pi]
 
     Turn -->|observation due| Observe
     Turn -->|reflection due| Reflect
-    AgentEnd -->|compactAfterTokens and idle| Trigger --> Compact --> Summary
+    AgentSettled -->|compactAfterTokens and idle| Trigger --> Compact --> Summary
 ```
 
 The high-level lifecycle:
@@ -353,7 +355,7 @@ Current behavior:
 
 * **Observation-centered memory.** The extension records useful session observations while you work.
 * **Durable reflections.** The extension distills stable facts that help the agent stay oriented over time.
-* **Fast compaction.** `session_before_compact` does not call a model or wait for background workers. It renders the current prepared memory state.
+* **Fast compaction.** When prepared V3 memory exists, `session_before_compact` renders it without calling a model or waiting for background workers. An empty V3 projection delegates to Pi's native summarizer instead of replacing prior context with an empty summary.
 * **Background memory work.** Observation and reflection work run from `turn_end` when their token clocks are due; dropper work runs only after successful reflection and prunes the folded active observation ledger toward `observationsPoolTargetTokens`.
 * **Source-backed recall.** Observations and reflections can be traced back through the `recall` tool.
 * **Visible/full views.** `/om:view` shows visible memory and `/om:view full` shows the full current memory state. Use `/om:status` for visible-vs-full drift and for the separate visible observation pool vs active observation pool.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -88,14 +88,14 @@ The dropper can only drop active observation ids. It cannot rewrite or merge obs
 
 ### Compaction hook
 
-The compaction hook runs during `session_before_compact`. In V3 it is deterministic and model-free:
+The compaction hook runs during `session_before_compact`. When V3 memory exists, it is deterministic and model-free:
 
 - it does not run observer, reflector, or dropper;
 - it does not call a model;
 - it does not wait for background memory workers;
 - it folds/projects ledger state and renders the summary.
 
-This is the main reason V3 compactions should feel instantaneous compared with V2.
+If the projection is empty, the hook returns no extension compaction and Pi uses its native summarizer. This preserves pre-cut context instead of persisting an empty summary. Prepared V3 compactions remain effectively instantaneous compared with V2.
 
 ## Ledger entries
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -103,9 +103,9 @@ Lower values distill reflections more often and therefore create more opportunit
 
 Default: `81000`.
 
-The auto-compaction trigger runs from Pi's `agent_end` hook. It counts raw/source tokens after the latest compaction boundary. If the count reaches `compactAfterTokens`, the extension defers with `setTimeout(0)`, checks that Pi is idle, re-checks the threshold, and calls `ctx.compact()`.
+The auto-compaction trigger runs from Pi's `agent_settled` hook, after retries and queued continuation finish. It counts raw/source tokens after the latest compaction boundary. If the count reaches `compactAfterTokens`, the extension defers with `setTimeout(0)`, checks that Pi is idle, re-checks the threshold, and calls `ctx.compact()`.
 
-This trigger does not wait for observer, reflector, or dropper work. Actual compaction summary creation happens later in `session_before_compact`, where V3 compaction is deterministic and model-free.
+This trigger does not wait for observer, reflector, or dropper work. Actual compaction summary creation happens later in `session_before_compact`. A non-empty V3 projection is rendered deterministically and model-free; an empty projection delegates to Pi's native summarizer so prior context is not replaced by an empty summary.
 
 Pi's own window-pressure compaction and manual compaction can still happen independently of this proactive trigger.
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -2,7 +2,7 @@
 
 This is the V3 technical reference for `pi-observational-memory`.
 
-V3 is ledger-centered: memory state is reconstructed by folding V3 ledger entries on the current branch. Compaction is model-free and renders a projection of that ledger into the summary the agent sees.
+V3 is ledger-centered: memory state is reconstructed by folding V3 ledger entries on the current branch. When that projection is non-empty, V3 renders it model-free into the summary the agent sees. Empty projections delegate to Pi's native summarizer.
 
 ## Runtime entry points
 
@@ -12,7 +12,7 @@ V3 is ledger-centered: memory state is reconstructed by folding V3 ledger entrie
 |---|---|
 | `turn_end` observer trigger | Maybe run the observer in the background. |
 | `turn_end` reflect/drop trigger | Maybe run the due reflector, then run dropper maintenance only after same-run successful reflection. |
-| `agent_end` compaction trigger | Maybe call `ctx.compact()` when idle and over `compactAfterTokens`. |
+| `agent_settled` compaction trigger | Maybe call `ctx.compact()` when idle and over `compactAfterTokens`, after Pi finishes retries and queued continuation. |
 | `session_before_compact` hook | Build the V3 compaction payload deterministically. |
 | `/om:status` | Show ledger counts, drift, progress clocks, and worker state. |
 | `/om:view` | Show visible or full memory content and attempt to copy the rendered memory text. |
@@ -23,7 +23,7 @@ V3 is ledger-centered: memory state is reconstructed by folding V3 ledger entrie
 ```mermaid
 flowchart TD
     TE[turn_end]
-    AE[agent_end]
+    AE[agent_settled]
     SBC[session_before_compact]
 
     ObsDue{raw tokens since observation coverage<br/>≥ observeAfterTokens?}
@@ -196,13 +196,12 @@ Reflector no-output and reflector failure skip same-turn dropper. Dropper failur
 
 ## Auto-compaction trigger
 
-The auto-compaction trigger runs on `agent_end`.
+The auto-compaction trigger runs on `agent_settled`, after Pi has finished automatic retries, automatic compaction, and queued continuation.
 
 It skips when:
 
 - `passive` is true;
 - compaction is already in flight;
-- the agent end event is a retryable error;
 - raw/source tokens since last compaction are below `compactAfterTokens`;
 - Pi is not idle after the deferred check;
 - the threshold is no longer met after the deferred check.
@@ -222,7 +221,8 @@ It does only deterministic work:
 3. Read `event.preparation.firstKeptEntryId` and `event.preparation.tokensBefore`.
 4. Build a compaction projection from branch entries and `firstKeptEntryId`.
 5. Render a summary from projected reflections and observations.
-6. Return `{ compaction: { summary, firstKeptEntryId, tokensBefore, details } }` where `details.type` is `om.folded`.
+6. If the summary is empty, return no extension result so Pi uses native compaction.
+7. Otherwise return `{ compaction: { summary, firstKeptEntryId, tokensBefore, details } }` where `details.type` is `om.folded`.
 
 It does not:
 
@@ -232,7 +232,7 @@ It does not:
 - wait for worker promises;
 - append ledger entries.
 
-If another compaction hook is already in flight, it returns `{ cancel: true }`.
+If another compaction hook is already in flight, it returns `{ cancel: true }`. Delegating an empty projection is intentionally different: Pi proceeds with its native summarizer so pre-cut context is preserved.
 
 ## Projections
 
@@ -337,7 +337,7 @@ V3 does not use V2 state shapes. Old V2 custom memory entries, old V2 compaction
 
 - The branch-local V3 ledger is the memory source of truth.
 - Pi compaction summaries represent what the agent sees.
-- Compaction is deterministic and model-free.
+- Non-empty V3 compaction projections are deterministic and model-free; empty projections delegate to Pi's native summarizer.
 - Observer input is raw/source entries only.
 - `coversUpToId` is a progress/projection watermark, not provenance.
 - Kept observations and reflections are rendered without paraphrase.

--- a/src/hooks/compaction-hook.ts
+++ b/src/hooks/compaction-hook.ts
@@ -1,4 +1,8 @@
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import type {
+	ExtensionAPI,
+	ExtensionContext,
+	SessionBeforeCompactEvent,
+} from "@earendil-works/pi-coding-agent";
 
 import type { Runtime } from "../runtime.js";
 import { buildCompactionProjection, renderSummary, type Entry } from "../session-ledger/index.js";
@@ -13,7 +17,7 @@ function observationsPoolMaxTokens(runtime: Runtime): number {
 }
 
 export function registerCompactionHook(pi: ExtensionAPI, runtime: Runtime): void {
-	pi.on("session_before_compact", async (event: any, ctx: any) => {
+	pi.on("session_before_compact", async (event: SessionBeforeCompactEvent, ctx: ExtensionContext) => {
 		if (runtime.compactHookInFlight) {
 			if (ctx.hasUI) {
 				ctx.ui.notify(
@@ -35,6 +39,10 @@ export function registerCompactionHook(pi: ExtensionAPI, runtime: Runtime): void
 				{ observationsPoolMaxTokens: observationsPoolMaxTokens(runtime) },
 			);
 			const summary = renderSummary(projection.reflections, projection.observations);
+			if (summary.length === 0) {
+				// Decline ownership so Pi's native summarizer preserves the pre-cut context.
+				return;
+			}
 
 			return {
 				compaction: {

--- a/src/hooks/compaction-trigger.ts
+++ b/src/hooks/compaction-trigger.ts
@@ -3,34 +3,13 @@ import { resolveCompactAfterTokens } from "../config.js";
 import { rawTokensSinceLastCompaction, type Entry } from "../session-ledger/index.js";
 import type { Runtime } from "../runtime.js";
 
-/**
- * Regex matching Pi's internal retryable error detection.
- * When the last assistant message in agent_end has stopReason "error" matching this pattern,
- * Pi will auto-retry — we must not trigger compaction between attempts.
- */
-const RETRYABLE_ERROR_RE =
-	/overloaded|provider.?returned.?error|rate.?limit|too many requests|429|500|502|503|504|service.?unavailable|server.?error|internal.?error|network.?error|connection.?error|connection.?refused|connection.?lost|websocket.?closed|websocket.?error|other side closed|fetch failed|upstream.?connect|reset before headers|socket hang up|ended without|http2 request did not get a response|timed? out|timeout|terminated|retry delay/i;
-
 export function registerCompactionTrigger(pi: ExtensionAPI, runtime: Runtime): void {
-	pi.on("agent_end", (event: any, ctx: any) => {
+	// Pi emits agent_settled only after retries, automatic compaction, and queued
+	// continuation have finished, so retry policy stays owned by Pi.
+	pi.on("agent_settled", (_event, ctx) => {
 		runtime.ensureConfig(ctx.cwd);
 		if (runtime.config.passive === true) return;
 		if (runtime.compactInFlight) return;
-
-		// Don't trigger compaction if Pi will auto-retry — the agent hasn't truly finished.
-		// Pi emits agent_end before its own retry check, so we must detect this ourselves.
-		// The next agent_end (after retry succeeds or exhausts attempts) will re-evaluate.
-		const lastAssistant = [...event.messages].reverse().find(
-			(m): m is Extract<typeof m, { role: "assistant" }> => m.role === "assistant",
-		);
-		if (
-			lastAssistant
-			&& lastAssistant.stopReason === "error"
-			&& lastAssistant.errorMessage
-			&& RETRYABLE_ERROR_RE.test(lastAssistant.errorMessage)
-		) {
-			return;
-		}
 
 		const entries = ctx.sessionManager.getBranch() as Entry[];
 		const tokens = rawTokensSinceLastCompaction(entries);

--- a/tests/compaction-hook.test.ts
+++ b/tests/compaction-hook.test.ts
@@ -52,26 +52,13 @@ function setup(args: { entries: TestEntry[]; observationsPoolMaxTokens?: number;
 }
 
 describe("V3 compaction hook", () => {
-	it("returns valid empty om.folded details when there is no V3 memory", async () => {
+	it("delegates to native compaction when there is no V3 memory", async () => {
 		const entries = [textCustomMessage("raw-1", "aaaa")];
 		const { run, runtime, pi } = setup({ entries });
 
 		const result = await run("raw-1");
 
-		expect(result).toMatchObject({
-			compaction: {
-				firstKeptEntryId: "raw-1",
-				tokensBefore: 123,
-				summary: "",
-				details: {
-					type: "om.folded",
-					version: 1,
-					fullFold: false,
-					observations: [],
-					reflections: [],
-				},
-			},
-		});
+		expect(result).toBeUndefined();
 		expect(runtime.resolveModel).not.toHaveBeenCalled();
 		expect(pi.appendEntry).not.toHaveBeenCalled();
 		expect(runtime.compactHookInFlight).toBe(false);
@@ -146,7 +133,7 @@ describe("V3 compaction hook", () => {
 		expect(result.compaction.details.reflections.map((ref: any) => ref.id)).toEqual(["eeeeeeeeeeee", "ffffffffffff"]);
 	});
 
-	it("ignores old V2 memory entries and details", async () => {
+	it("delegates to native compaction when only old V2 memory exists", async () => {
 		const entries = [
 			textCustomMessage("raw-1", "aaaa"),
 			oldV2ObservationEntry("v2-obs"),
@@ -154,13 +141,9 @@ describe("V3 compaction hook", () => {
 		];
 		const { run } = setup({ entries });
 
-		const result = await run("cmp-v2") as any;
+		const result = await run("cmp-v2");
 
-		expect(result.compaction.details).toMatchObject({
-			type: "om.folded",
-			observations: [],
-			reflections: [],
-		});
+		expect(result).toBeUndefined();
 	});
 
 	it("does not wait for worker promises or call model resolution", async () => {
@@ -172,7 +155,7 @@ describe("V3 compaction hook", () => {
 			new Promise((_, reject) => setTimeout(() => reject(new Error("timed out")), 50)),
 		]);
 
-		expect(result).toMatchObject({ compaction: { details: { type: "om.folded" } } });
+		expect(result).toBeUndefined();
 		expect(runtime.resolveModel).not.toHaveBeenCalled();
 	});
 

--- a/tests/compaction-trigger.test.ts
+++ b/tests/compaction-trigger.test.ts
@@ -7,7 +7,7 @@ function captureHandler(args: { compactAfterTokens?: number; compactAfterTokensM
 	let handler: ((event: unknown, ctx: unknown) => void) | undefined;
 	const pi = {
 		on: vi.fn((name: string, cb: typeof handler) => {
-			expect(name).toBe("agent_end");
+			expect(name).toBe("agent_settled");
 			handler = cb;
 		}),
 	};
@@ -24,20 +24,12 @@ function captureHandler(args: { compactAfterTokens?: number; compactAfterTokensM
 		reflectDropPromise: new Promise(() => {}),
 	};
 	registerCompactionTrigger(pi as any, runtime as any);
-	if (!handler) throw new Error("agent_end handler was not registered");
+	if (!handler) throw new Error("agent_settled handler was not registered");
 	return { handler, runtime };
 }
 
-function agentEnd(errorMessage?: string) {
-	return {
-		type: "agent_end",
-		messages: [
-			{ role: "user", content: "hello" },
-			errorMessage
-				? { role: "assistant", content: [], stopReason: "error", errorMessage }
-				: { role: "assistant", content: "done", stopReason: "end_turn" },
-		],
-	};
+function agentSettled() {
+	return { type: "agent_settled" };
 }
 
 function fakeCtx(branches: TestEntry[][], overrides: Record<string, unknown> = {}) {
@@ -71,7 +63,7 @@ describe("V3 compaction trigger", () => {
 		const { handler, runtime } = captureHandler({ compactAfterTokens: 3 });
 		const ctx = fakeCtx([belowBranch]);
 
-		handler(agentEnd(), ctx);
+		handler(agentSettled(), ctx);
 		await vi.runAllTimersAsync();
 
 		expect(runtime.compactInFlight).toBe(false);
@@ -82,7 +74,7 @@ describe("V3 compaction trigger", () => {
 		const { handler, runtime } = captureHandler({ compactAfterTokens: 3 });
 		const ctx = fakeCtx([dueBranch]);
 
-		handler(agentEnd(), ctx);
+		handler(agentSettled(), ctx);
 		expect(runtime.compactInFlight).toBe(true);
 		await vi.runAllTimersAsync();
 
@@ -97,7 +89,7 @@ describe("V3 compaction trigger", () => {
 		const { handler, runtime } = captureHandler({ passive: true });
 		const ctx = fakeCtx([dueBranch]);
 
-		handler(agentEnd(), ctx);
+		handler(agentSettled(), ctx);
 		await vi.runAllTimersAsync();
 
 		expect(runtime.compactInFlight).toBe(false);
@@ -109,21 +101,9 @@ describe("V3 compaction trigger", () => {
 		const { handler } = captureHandler({ compactInFlight: true });
 		const ctx = fakeCtx([dueBranch]);
 
-		handler(agentEnd(), ctx);
+		handler(agentSettled(), ctx);
 		await vi.runAllTimersAsync();
 
-		expect(ctx.sessionManager.getBranch).not.toHaveBeenCalled();
-		expect(ctx.compact).not.toHaveBeenCalled();
-	});
-
-	it("skips retryable assistant errors", async () => {
-		const { handler, runtime } = captureHandler();
-		const ctx = fakeCtx([dueBranch]);
-
-		handler(agentEnd("fetch failed: connection lost"), ctx);
-		await vi.runAllTimersAsync();
-
-		expect(runtime.compactInFlight).toBe(false);
 		expect(ctx.sessionManager.getBranch).not.toHaveBeenCalled();
 		expect(ctx.compact).not.toHaveBeenCalled();
 	});
@@ -132,7 +112,7 @@ describe("V3 compaction trigger", () => {
 		const { handler } = captureHandler({ compactAfterTokens: 3 });
 		const ctx = fakeCtx([dueBranch]);
 
-		handler(agentEnd(), ctx);
+		handler(agentSettled(), ctx);
 		await vi.runAllTimersAsync();
 
 		expect(ctx.compact).toHaveBeenCalledTimes(1);
@@ -142,7 +122,7 @@ describe("V3 compaction trigger", () => {
 		const { handler, runtime } = captureHandler({ compactAfterTokens: 3 });
 		const ctx = fakeCtx([dueBranch], { isIdle: vi.fn(() => false) });
 
-		handler(agentEnd(), ctx);
+		handler(agentSettled(), ctx);
 		await vi.runAllTimersAsync();
 
 		expect(ctx.compact).not.toHaveBeenCalled();
@@ -157,7 +137,7 @@ describe("V3 compaction trigger", () => {
 		const { handler, runtime } = captureHandler({ compactAfterTokens: 3 });
 		const ctx = fakeCtx([dueBranch, belowBranch]);
 
-		handler(agentEnd(), ctx);
+		handler(agentSettled(), ctx);
 		await vi.runAllTimersAsync();
 
 		expect(ctx.compact).not.toHaveBeenCalled();
@@ -178,7 +158,7 @@ describe("V3 compaction trigger", () => {
 		];
 		const ctx = fakeCtx([branch]);
 
-		handler(agentEnd(), ctx);
+		handler(agentSettled(), ctx);
 		await vi.runAllTimersAsync();
 
 		expect(ctx.compact).toHaveBeenCalledTimes(1);
@@ -194,7 +174,7 @@ describe("V3 compaction trigger", () => {
 			});
 			const ctx = fakeCtx([dueBranch], { model: { contextWindow: 4 } });
 
-			handler(agentEnd(), ctx);
+			handler(agentSettled(), ctx);
 			await vi.runAllTimersAsync();
 
 			expect(ctx.compact).toHaveBeenCalledTimes(1);
@@ -209,7 +189,7 @@ describe("V3 compaction trigger", () => {
 			});
 			const ctx = fakeCtx([belowBranch], { model: { contextWindow: 4 } });
 
-			handler(agentEnd(), ctx);
+			handler(agentSettled(), ctx);
 			await vi.runAllTimersAsync();
 
 			expect(ctx.compact).not.toHaveBeenCalled();
@@ -224,7 +204,7 @@ describe("V3 compaction trigger", () => {
 			});
 			const ctx = fakeCtx([dueBranch], { model: undefined });
 
-			handler(agentEnd(), ctx);
+			handler(agentSettled(), ctx);
 			await vi.runAllTimersAsync();
 
 			expect(ctx.compact).not.toHaveBeenCalled();
@@ -238,7 +218,7 @@ describe("V3 compaction trigger", () => {
 			});
 			const ctx = fakeCtx([dueBranch], { model: { contextWindow: 0 } });
 
-			handler(agentEnd(), ctx);
+			handler(agentSettled(), ctx);
 			await vi.runAllTimersAsync();
 
 			expect(ctx.compact).not.toHaveBeenCalled();
@@ -257,7 +237,7 @@ describe("V3 compaction trigger", () => {
 				isIdle: vi.fn(() => false),
 			});
 
-			handler(agentEnd(), ctx);
+			handler(agentSettled(), ctx);
 			await vi.runAllTimersAsync();
 
 			expect(ctx.compact).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary

- delegate empty V3 memory projections to Pi's native compactor instead of persisting an empty summary
- trigger proactive compaction from `agent_settled`, letting Pi own retry and queued-continuation sequencing
- document the Pi 0.81+ lifecycle requirement and the native fallback
- add a minimal Node 24 CI workflow for typecheck and tests

## Why

The current hook always returns an extension compaction. Before the first observation is recorded—or after observer/model failures—`renderSummary([], [])` returns an empty string. Pi accepts that extension result verbatim, so pre-cut context can be replaced by an empty summary.

Returning no extension result when the V3 projection is empty lets Pi run its native summarizer. Non-empty V3 projections retain the existing deterministic, model-free path.

Using `agent_settled` also removes the extension's copied retry-error regex. Pi emits that lifecycle event only after retries, automatic compaction, and queued continuation have settled.

## Verification

- `npm run typecheck`
- `npm test` — 25 files, 240 tests passed
- GitHub Actions CI on Node 24: https://github.com/git-geeky/pi-observational-memory/actions/runs/31466466510
