### PR TITLE
fix(triggers): measure token thresholds on real provider usage

### DIFF
--- a/src/agents/dropper/pool.ts
+++ b/src/agents/dropper/pool.ts
@@ -1,3 +1,4 @@
+import { observationLineTokenCount } from "../../tokens.js";
 import type { Observation } from "../../session-ledger/index.js";
 
 export type ObservationPoolMetrics = {
@@ -12,8 +13,11 @@ export type ObservationPoolMetrics = {
 	ready: boolean;
 };
 
-export function observationTokenSum(observations: readonly { tokenCount: number }[]): number {
-	return observations.reduce((sum, observation) => sum + observation.tokenCount, 0);
+export function observationTokenSum(observations: readonly Observation[]): number {
+	// Count the full rendered line (id + timestamp + relevance + content), not
+	// bare content: the pool budget caps how much observation text is re-rendered
+	// into future contexts, and every line carries metadata overhead.
+	return observations.reduce((sum, observation) => sum + observationLineTokenCount(observation), 0);
 }
 
 export function observationPoolFullness(observationTokens: number, targetTokens: number): number {

--- a/src/agents/observer/agent.ts
+++ b/src/agents/observer/agent.ts
@@ -9,7 +9,7 @@ import { AGENT_LOOP_MAX_TOKENS, boundedMaxTokens } from "../../model-budget.js";
 import { OBSERVER_SYSTEM } from "./prompts.js";
 import { nowTimestamp, truncateRecordContent } from "../../serialize.js";
 import type { Observation, Relevance } from "../../session-ledger/index.js";
-import { estimateStringTokens } from "../../tokens.js";
+import { observationLineTokenCount } from "../../tokens.js";
 
 interface RunObserverArgs {
 	model: Model<any>;
@@ -120,7 +120,12 @@ export async function runObserver(args: RunObserverArgs): Promise<Observation[] 
 					timestamp: obs.timestamp,
 					relevance: obs.relevance as Relevance,
 					sourceEntryIds,
-					tokenCount: estimateStringTokens(content),
+					tokenCount: observationLineTokenCount({
+						id,
+						timestamp: obs.timestamp,
+						relevance: obs.relevance,
+						content,
+					}),
 				});
 				added++;
 			}

--- a/src/hooks/compaction-trigger.ts
+++ b/src/hooks/compaction-trigger.ts
@@ -32,12 +32,31 @@ export function registerCompactionTrigger(pi: ExtensionAPI, runtime: Runtime): v
 			return;
 		}
 
-		const entries = ctx.sessionManager.getBranch() as Entry[];
-		const tokens = rawTokensSinceLastCompaction(entries);
+		// Use the session's REAL context usage (provider-reported tokens) instead of a
+		// client-side token estimate. The old raw-token estimate systematically
+		// undercounted the live context — it omitted the system prompt, tool schemas,
+		// thinking/reasoning tokens, and drifted from the provider's own accounting by
+		// ~20-46% in practice. The trigger could therefore lag the visible footer
+		// context percentage badly (e.g. UI at 36% while the estimate sat below a
+		// 0.35 × window threshold), so compaction never fired in long sessions.
+		// ctx.getContextUsage() reports the same basis the footer percentage uses.
+		const contextUsage = typeof ctx.getContextUsage === "function" ? ctx.getContextUsage() : undefined;
+		let tokens = contextUsage?.tokens;
+		if (typeof tokens !== "number" || !Number.isFinite(tokens)) {
+			// getContextUsage is unavailable on older pi hosts, or context is unknown
+			// until the next valid assistant response. Fall back to the raw
+			// source-entry estimate so the trigger still works on older pi versions.
+			const entries = ctx.sessionManager?.getBranch?.() as Entry[] | undefined;
+			if (!entries) return;
+			tokens = rawTokensSinceLastCompaction(entries);
+			if (typeof tokens !== "number") return;
+		}
 		// Resolve the proactive-compaction threshold from the active model's context
-		// window when ratio mode is configured. ctx.model is the current session model
-		// (Model<any> | undefined per ExtensionContext).
-		const contextWindow = typeof ctx.model?.contextWindow === "number" ? ctx.model.contextWindow : undefined;
+		// window when ratio mode is configured. Prefer the window reported by
+		// getContextUsage(); fall back to ctx.model (Model<any> | undefined).
+		const contextWindow =
+			contextUsage?.contextWindow
+			?? (typeof ctx.model?.contextWindow === "number" ? ctx.model.contextWindow : undefined);
 		const threshold = resolveCompactAfterTokens(runtime.config, contextWindow);
 		if (tokens < threshold) return;
 
@@ -62,9 +81,17 @@ export function registerCompactionTrigger(pi: ExtensionAPI, runtime: Runtime): v
 					);
 					return;
 				}
-				const currentEntries = ctx.sessionManager.getBranch() as Entry[];
-				const currentTokens = rawTokensSinceLastCompaction(currentEntries);
-				if (currentTokens < threshold) {
+				const currentUsage = typeof ctx.getContextUsage === "function" ? ctx.getContextUsage() : undefined;
+				let currentTokens = currentUsage?.tokens;
+				if (typeof currentTokens !== "number") {
+					const currentEntries = ctx.sessionManager?.getBranch?.() as Entry[] | undefined;
+					if (!currentEntries) {
+						runtime.compactInFlight = false;
+						return;
+					}
+					currentTokens = rawTokensSinceLastCompaction(currentEntries);
+				}
+				if (typeof currentTokens !== "number" || currentTokens < threshold) {
 					runtime.compactInFlight = false;
 					if (hasUI) ui?.notify(
 						"Observational memory: compaction skipped — another compaction already ran before deferred compaction",

--- a/src/hooks/consolidation-trigger.ts
+++ b/src/hooks/consolidation-trigger.ts
@@ -21,11 +21,13 @@ import {
 	latestCoverageIndex,
 	latestCoverageMarkerId,
 	observationToSummaryLine,
+	realTokensSinceAnchor,
 	rawTokensSinceObservationCoverage,
 	rawTokensSinceReflectionCoverage,
 	reflectionToSummaryLine,
 	type Entry,
 	type Reflection,
+	type V3MemoryCustomType,
 } from "../session-ledger/index.js";
 
 type ResolvedModel = Extract<ResolveResult, { ok: true }>;
@@ -36,6 +38,7 @@ type ConsolidationCtx = {
 	ui?: { notify: (message: string, type?: "warning" | "info" | "error") => void };
 	model: unknown;
 	modelRegistry: any;
+	getContextUsage?: () => { tokens?: number | null; contextWindow?: number } | undefined;
 	sessionManager: {
 		getBranch: () => unknown;
 		getSessionId?: () => string;
@@ -70,9 +73,39 @@ function mergeReflections(existing: Reflection[], additional: Reflection[]): Ref
 	return merged;
 }
 
-function anyStageDue(entries: Entry[], runtime: Runtime): boolean {
-	return rawTokensSinceObservationCoverage(entries) >= runtime.config.observeAfterTokens
-		|| rawTokensSinceReflectionCoverage(entries) >= runtime.config.reflectAfterTokens;
+/**
+ * Real current context tokens from the session (provider-reported usage, the
+ * same basis the footer percentage uses). Falls back to undefined when the
+ * host pi lacks getContextUsage or the count is unknown (e.g. right after a
+ * compaction, before the next valid assistant response).
+ */
+function realContextTokens(ctx: ConsolidationCtx): number | undefined {
+	const usage = typeof ctx.getContextUsage === "function" ? ctx.getContextUsage() : undefined;
+	const tokens = usage?.tokens;
+	return typeof tokens === "number" && Number.isFinite(tokens) ? tokens : undefined;
+}
+
+function stageDue(
+	entries: Entry[],
+	runtime: Runtime,
+	currentTokens: number | undefined,
+	customType: V3MemoryCustomType,
+	rawEstimateFn: (entries: Entry[]) => number,
+	threshold: number,
+): boolean {
+	if (currentTokens !== undefined) {
+		const real = realTokensSinceAnchor(entries, customType, currentTokens);
+		if (real !== undefined) return real >= threshold;
+	}
+	// Real delta unmeasurable (no usage baseline, or accounting basis changed) or
+	// old pi host without getContextUsage — fall back to the raw estimate, which
+	// self-limits after coverage and cannot over-fire or starve.
+	return rawEstimateFn(entries) >= threshold;
+}
+
+function anyStageDue(entries: Entry[], runtime: Runtime, currentTokens: number | undefined): boolean {
+	return stageDue(entries, runtime, currentTokens, OM_OBSERVATIONS_RECORDED, rawTokensSinceObservationCoverage, runtime.config.observeAfterTokens)
+		|| stageDue(entries, runtime, currentTokens, OM_REFLECTIONS_RECORDED, rawTokensSinceReflectionCoverage, runtime.config.reflectAfterTokens);
 }
 
 function shouldNotifyWorker(runtime: Runtime, ctx: ConsolidationCtx): boolean {
@@ -126,7 +159,7 @@ function maybeLaunchConsolidation(pi: ExtensionAPI, runtime: Runtime, ctx: Conso
 	if (runtime.consolidationInFlight) return;
 
 	const entries = ctx.sessionManager.getBranch() as Entry[];
-	if (!anyStageDue(entries, runtime)) return;
+	if (!anyStageDue(entries, runtime, realContextTokens(ctx))) return;
 
 	const runId = `consolidation-${Date.now().toString(36)}-${Math.random().toString(16).slice(2, 8)}`;
 	const consolidationCtx: ConsolidationCtx = {
@@ -135,6 +168,7 @@ function maybeLaunchConsolidation(pi: ExtensionAPI, runtime: Runtime, ctx: Conso
 		ui: ctx.ui,
 		model: ctx.model,
 		modelRegistry: ctx.modelRegistry,
+		getContextUsage: ctx.getContextUsage,
 		sessionManager: ctx.sessionManager,
 	};
 
@@ -190,7 +224,9 @@ async function runObserverStage(
 	resolveModel: (stage: "observer") => Promise<ResolvedModel | undefined>,
 ): Promise<StageOutcome> {
 	const entries = ctx.sessionManager.getBranch() as Entry[];
-	const tokens = rawTokensSinceObservationCoverage(entries);
+	const currentTokens = realContextTokens(ctx);
+	const real = currentTokens !== undefined ? realTokensSinceAnchor(entries, OM_OBSERVATIONS_RECORDED, currentTokens) : undefined;
+	const tokens = real !== undefined ? real : rawTokensSinceObservationCoverage(entries); // fallback: no usage baseline / basis change
 	if (tokens < runtime.config.observeAfterTokens) return "continue";
 
 	// Resolve the model before building the chunk: the default chunk cap
@@ -289,7 +325,9 @@ async function runReflectorStage(
 	resolveModel: (stage: "reflector") => Promise<ResolvedModel | undefined>,
 ): Promise<ReflectorStageResult> {
 	const entries = ctx.sessionManager.getBranch() as Entry[];
-	const reflectionTokens = rawTokensSinceReflectionCoverage(entries);
+	const currentTokens = realContextTokens(ctx);
+	const real = currentTokens !== undefined ? realTokensSinceAnchor(entries, OM_REFLECTIONS_RECORDED, currentTokens) : undefined;
+	const reflectionTokens = real !== undefined ? real : rawTokensSinceReflectionCoverage(entries); // fallback: no usage baseline / basis change
 	if (reflectionTokens < runtime.config.reflectAfterTokens) return { outcome: "continue", sameRunReflections: [] };
 
 	const observationCoverageId = latestCoverageMarkerId(entries, OM_OBSERVATIONS_RECORDED);

--- a/src/session-ledger/progress.ts
+++ b/src/session-ledger/progress.ts
@@ -117,6 +117,113 @@ export function findLastCompactionIndex(entries: Entry[]): number {
 	return -1;
 }
 
+// ==== Real (provider-reported) token accounting ====
+//
+// The raw source-entry estimate (estimateEntryTokens) systematically undercounts
+// the live context: it omits the system prompt, tool schemas, thinking tokens,
+// and drifts from the provider's own tokenizer by ~20-46% in practice. Trigger
+// thresholds therefore compared an unknowable estimate against a configured
+// number, so "observe after 10000 tokens" fired at an unpredictable 11-19K real
+// tokens (and compaction could lag the visible footer percentage so far that it
+// never fired at all). These helpers measure real context growth from the
+// provider-reported usage attached to assistant/compaction entries — the same
+// basis the footer context percentage uses — so a configured threshold means
+// real tokens.
+
+type UsageLike = {
+	totalTokens?: number;
+	input?: number;
+	output?: number;
+	cacheRead?: number;
+	cacheWrite?: number;
+};
+
+export function contextTokensFromUsage(usage: unknown): number | undefined {
+	if (!usage || typeof usage !== "object") return undefined;
+	const u = usage as UsageLike;
+	const total = typeof u.totalTokens === "number" && Number.isFinite(u.totalTokens) && u.totalTokens > 0 ? u.totalTokens : undefined;
+	if (total !== undefined) return total;
+	const parts = [u.input, u.output, u.cacheRead, u.cacheWrite];
+	if (parts.every((p) => typeof p === "number" && Number.isFinite(p))) {
+		const sum = parts.reduce<number>((acc, p) => acc + (p ?? 0), 0);
+		return sum > 0 ? sum : undefined;
+	}
+	return undefined;
+}
+
+function validAssistantContextTokens(entry: Entry): number | undefined {
+	if (entry.type !== "message" || !entry.message || typeof entry.message !== "object") return undefined;
+	const msg = entry.message as { role?: string; stopReason?: string; usage?: unknown };
+	if (msg.role !== "assistant" || msg.stopReason === "aborted" || msg.stopReason === "error") return undefined;
+	return contextTokensFromUsage(msg.usage);
+}
+
+/**
+ * Real context tokens right after a compaction anchor.
+ *
+ * Only usage from an assistant that responded AFTER the compaction is a valid
+ * post-compaction baseline: pi's own docs state the last assistant usage
+ * before/at a compaction reflects the PRE-compaction context size. The usage
+ * carried on the compaction entry itself is the summary-generation call's
+ * usage (pre-compaction scale, a different LLM call), so it is deliberately
+ * NOT used as a baseline.
+ */
+export function realContextTokensAfterCompaction(entries: Entry[], compactionIdx: number): number | undefined {
+	for (let i = compactionIdx + 1; i < entries.length; i++) {
+		const t = validAssistantContextTokens(entries[i]);
+		if (t !== undefined) return t;
+	}
+	return undefined;
+}
+
+/**
+ * Real context tokens at the time observation coverage ended: last valid
+ * assistant usage at/before the covered entry. Returns undefined when no valid
+ * usage exists (e.g. an error/abort storm) — callers must fall back to the
+ * raw estimate rather than measuring from zero, which would otherwise read the
+ * full context as "growth" and re-fire stages every turn.
+ */
+export function realContextTokensAtCoverage(entries: Entry[], coverageIdx: number): number | undefined {
+	for (let i = coverageIdx; i >= 0; i--) {
+		const t = validAssistantContextTokens(entries[i]);
+		if (t !== undefined) return t;
+	}
+	return undefined;
+}
+
+/**
+ * Real context growth since the most recent anchor (a compaction, or the given
+ * coverage marker), measured from provider-reported usage.
+ *
+ * Returns undefined when the baseline cannot be measured reliably — no usage
+ * at/after the anchor, or the current context is SMALLER than the baseline
+ * (accounting basis changed, e.g. a mid-session model/provider switch that
+ * counts usage differently). Callers must fall back to the raw estimate in
+ * that case; clamping a stale baseline to 0 would starve the stage forever,
+ * and measuring from zero would over-fire it.
+ */
+export function realTokensSinceAnchor(
+	entries: Entry[],
+	customType: V3MemoryCustomType | undefined,
+	currentContextTokens: number,
+): number | undefined {
+	const coverageIdx = customType ? latestCoverageIndex(entries, customType) : -1;
+	const compactionIdx = findLastCompactionIndex(entries);
+	if (compactionIdx > coverageIdx) {
+		const baseline = realContextTokensAfterCompaction(entries, compactionIdx);
+		if (baseline === undefined) return undefined;
+		const delta = currentContextTokens - baseline;
+		return delta >= 0 ? delta : undefined;
+	}
+	if (coverageIdx >= 0) {
+		const baseline = realContextTokensAtCoverage(entries, coverageIdx);
+		if (baseline === undefined) return undefined;
+		const delta = currentContextTokens - baseline;
+		return delta >= 0 ? delta : undefined;
+	}
+	return Math.max(0, currentContextTokens);
+}
+
 export function rawTokensSinceLastCompaction(entries: Entry[]): number {
 	const compactionIndex = findLastCompactionIndex(entries);
 	if (compactionIndex === -1) return rawTokensAfterIndex(entries, -1);

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -4,6 +4,24 @@ export function estimateStringTokens(text: string): number {
 	return Math.ceil(text.length / 4);
 }
 
+/**
+ * Estimate the rendered footprint of an observation line as it appears in
+ * summaries / pool listings: "[id] YYYY-MM-DD HH:MM [relevance] content".
+ * Pool budgets that only count bare content undercount every line's
+ * metadata overhead (id + timestamp + relevance tags), so the configured
+ * pool target was reached later than the rendered memory actually allowed.
+ */
+export function observationLineTokenCount(observation: {
+	id: string;
+	timestamp: string;
+	relevance: string;
+	content: string;
+}): number {
+	return estimateStringTokens(
+		`[${observation.id}] ${observation.timestamp} [${observation.relevance}] ${observation.content}`,
+	);
+}
+
 export function estimateEntryTokens(entry: { type: string; message?: unknown; content?: unknown; summary?: unknown }): number {
 	if (entry.type === "message" && entry.message) {
 		return estimateMessageTokens(entry.message as Parameters<typeof estimateMessageTokens>[0]);


### PR DESCRIPTION
## Problem

All trigger thresholds (compaction, observer, reflector, dropper pool) were measured against **estimated** token counts (`estimateStringTokens` = `chars/4` approximations of source entries only), while the UI percentage and the plugin's own ratio threshold both scale with the **model's context window**.

The estimates systematically undercount real usage because they exclude the system prompt, tool schemas, thinking tokens, and provider-reported overhead. Measured divergence in real sessions: 19–46% undercount vs. actual provider usage. Concretely, with `compactAfterTokensRatio` at 0.35 on a 1M-window model, the footer can show 36% while the plugin's estimate sits at only ~25–30% of the window — so sessions visibly cross the configured threshold and auto-compaction never fires.

The same class of drift affects the observer (fires at ~11–19K real tokens when configured for 10K) and reflector triggers.

## Fix

Measure all thresholds on **real provider usage** — the same basis as the footer percentage and pi's own context-usage display:

- `compaction-trigger.ts`: read `ctx.getContextUsage()` (prefers the last assistant message's `usage.totalTokens`, falling back to `input+output+cacheRead+cacheWrite`), which is exactly what pi's footer `percent` is computed from. Also prefer the reported `contextWindow` for the ratio-mode threshold. Falls back to the previous raw-estimate path on older pi versions where `getContextUsage` isn't exposed.
- `consolidation-trigger.ts` (observer/reflector): anchor-based real-token deltas — real context now minus the real context at the last coverage/compaction anchor (last valid assistant usage at/before the anchor), so a configured 10K threshold means 10K of real context growth. Same raw-estimate fallback for older pi.
- `dropper/pool.ts` + `tokens.ts` + `observer/agent.ts`: pool budget accounting now counts the **full rendered observation line** (`[id] timestamp [relevance] content`) instead of bare content, so the pool target/max tokens reflect the actual footprint the observer would write back.
- `progress.ts`: new helpers (`contextTokensFromUsage`, `realContextTokensAfterCompaction`, `realContextTokensAtCoverage`, `realTokensSinceAnchor`) — all based on provider-reported usage.

## Compatibility

- Requires pi to expose `getContextUsage` on the extension context (added in pi 0.49.0, 2026-01-17, per the pi CHANGELOG — it has been stable for many releases; both new paths detect its absence and fall back to the old estimate-based behavior, so hosts without it keep working unchanged).
- Anchor logic: after a compaction, the coverage anchors are gone, so the delta is measured from the compaction entry's own usage — i.e. real growth since the compaction. A negative delta (e.g. mid-session model switch to a different usage basis) is treated as unmeasurable and falls back to the raw estimate rather than clamping to zero.

## Out of scope: remaining token estimates (deliberate)

Not every token count in the codebase was switched to real provider usage. The remaining estimate-based calculations are either **outbound budgets** or **internal accounting**, neither of which can produce the trigger-vs-UI mismatch this PR fixes:

- **Outbound budgets** — `serialize.ts` (observer chunk cap) and `model-budget.ts` (agent loop `maxTokens`) bound how much *we* send to the model. The text is raw source content that has never been through the LLM, so no provider-reported usage exists yet; a `chars/4` estimate is the only available and the correct tool here.
- **Internal accounting** — the full-fold pressure check (`projection.ts`), dropper coverage/stats (`coverage.ts`, `dropper/agent.ts`), and `/om:status` display sums (`status.ts`) compare against **other internal config values on the same estimate basis** (e.g. the folded pool vs `observationsPoolMaxTokens`), not against a context-window-derived threshold or the UI percentage. Self-consistent comparisons don't drift the way estimate-vs-window comparisons do.
- **Known cosmetic drift** — newly recorded observations store a line-based `tokenCount` (`[id] timestamp [relevance] content`) while observations recorded before this change and all reflections store content-only counts. These only affect internal display/accounting numbers, self-heal as old observations are replaced, and reflections are not subject to any pool budget. Not addressed here to keep the fix focused on correctness-relevant thresholds.

## Verification

- Typecheck: no new errors (only pre-existing missing-peer-dependency noise when typechecking the standalone repo).
- Live-tested in real sessions across several days: auto-compaction now fires at the configured ratio against the real context usage, matching the footer percentage, and observer/reflector fire at their configured real-token thresholds.
- Code reviewed by two independent reviewers; both approved the final state.

