### PR TITLE
fix: cancel stale deferred compaction

### DIFF
--- a/src/hooks/compaction-trigger.ts
+++ b/src/hooks/compaction-trigger.ts
@@ -12,6 +12,18 @@ const RETRYABLE_ERROR_RE =
 	/overloaded|provider.?returned.?error|rate.?limit|too many requests|429|500|502|503|504|service.?unavailable|server.?error|internal.?error|network.?error|connection.?error|connection.?refused|connection.?lost|websocket.?closed|websocket.?error|other side closed|fetch failed|upstream.?connect|reset before headers|socket hang up|ended without|http2 request did not get a response|timed? out|timeout|terminated|retry delay/i;
 
 export function registerCompactionTrigger(pi: ExtensionAPI, runtime: Runtime): void {
+	let deferredTimer: ReturnType<typeof setTimeout> | undefined;
+	let lifecycleGeneration = 0;
+
+	pi.on("session_shutdown", () => {
+		lifecycleGeneration += 1;
+		if (deferredTimer !== undefined) {
+			clearTimeout(deferredTimer);
+			deferredTimer = undefined;
+		}
+		runtime.compactInFlight = false;
+	});
+
 	pi.on("agent_end", (event: any, ctx: any) => {
 		runtime.ensureConfig(ctx.cwd);
 		if (runtime.config.passive === true) return;
@@ -71,7 +83,13 @@ export function registerCompactionTrigger(pi: ExtensionAPI, runtime: Runtime): v
 		);
 
 		runtime.compactInFlight = true;
-		setTimeout(() => {
+		const generation = lifecycleGeneration;
+		deferredTimer = setTimeout(() => {
+			deferredTimer = undefined;
+			if (generation !== lifecycleGeneration) {
+				runtime.compactInFlight = false;
+				return;
+			}
 			try {
 				if (!ctx.isIdle()) {
 					runtime.compactInFlight = false;
@@ -101,10 +119,12 @@ export function registerCompactionTrigger(pi: ExtensionAPI, runtime: Runtime): v
 				}
 				ctx.compact({
 					onComplete: () => {
+						if (generation !== lifecycleGeneration) return;
 						runtime.compactInFlight = false;
 						if (hasUI) ui?.notify("Observational memory: compaction complete", "info");
 					},
 					onError: (error: { message: string }) => {
+						if (generation !== lifecycleGeneration) return;
 						runtime.compactInFlight = false;
 						if (error.message === "Compaction cancelled") {
 							// We already notified the user with the real reason before returning { cancel: true }.
@@ -114,6 +134,7 @@ export function registerCompactionTrigger(pi: ExtensionAPI, runtime: Runtime): v
 					},
 				});
 			} catch (error) {
+				if (generation !== lifecycleGeneration) return;
 				runtime.compactInFlight = false;
 				const msg = error instanceof Error ? error.message : String(error);
 				if (hasUI) ui?.notify(`Observational memory: compact threw: ${msg}`, "error");

--- a/tests/compaction-trigger.test.ts
+++ b/tests/compaction-trigger.test.ts
@@ -5,10 +5,11 @@ import { compactionEntry, textCustomMessage, type TestEntry } from "./fixtures/s
 
 function captureHandler(args: { compactAfterTokens?: number; compactAfterTokensMode?: "calibrated" | "ratio"; compactAfterTokensRatio?: number; passive?: boolean; compactInFlight?: boolean } = {}) {
 	let handler: ((event: unknown, ctx: unknown) => void) | undefined;
+	let shutdown: ((event: unknown, ctx: unknown) => void) | undefined;
 	const pi = {
 		on: vi.fn((name: string, cb: typeof handler) => {
-			expect(name).toBe("agent_end");
-			handler = cb;
+			if (name === "agent_end") handler = cb;
+			if (name === "session_shutdown") shutdown = cb;
 		}),
 	};
 	const runtime = {
@@ -25,7 +26,8 @@ function captureHandler(args: { compactAfterTokens?: number; compactAfterTokensM
 	};
 	registerCompactionTrigger(pi as any, runtime as any);
 	if (!handler) throw new Error("agent_end handler was not registered");
-	return { handler, runtime };
+	if (!shutdown) throw new Error("session_shutdown handler was not registered");
+	return { handler, shutdown, runtime };
 }
 
 function agentEnd(errorMessage?: string) {
@@ -151,6 +153,21 @@ describe("V3 compaction trigger", () => {
 			"Observational memory: compaction deferred — agent became busy before compaction",
 			"info",
 		);
+	});
+
+	it("cancels deferred compaction when the session shuts down", async () => {
+		const { handler, shutdown, runtime } = captureHandler({ compactAfterTokens: 3 });
+		const ctx = fakeCtx([dueBranch]);
+
+		handler(agentEnd(), ctx);
+		expect(runtime.compactInFlight).toBe(true);
+		shutdown({ type: "session_shutdown", reason: "new" }, ctx);
+		await vi.runAllTimersAsync();
+
+		expect(runtime.compactInFlight).toBe(false);
+		expect(ctx.isIdle).not.toHaveBeenCalled();
+		expect(ctx.sessionManager.getBranch).toHaveBeenCalledTimes(1);
+		expect(ctx.compact).not.toHaveBeenCalled();
 	});
 
 	it("re-checks threshold after deferral and skips if another compaction already reduced pressure", async () => {


### PR DESCRIPTION
## Intent
Prevent deferred observational-memory compaction from calling a stale Pi session context after session replacement, reload, fork, or shutdown.

## What changed
- Cancel the deferred compaction timer on `session_shutdown`.
- Invalidate callbacks from the previous session lifecycle.
- Ignore late completion/error callbacks from invalidated compactions.
- Add a regression test covering shutdown before the deferred timer fires.

## Verification
- `npm run typecheck` ✅
- `npm test -- --run tests/compaction-trigger.test.ts` ✅ 15/15
- Full `npm test` baseline comparison: the same 14 unrelated failures reproduce on clean `master`; no changed-file regressions.
