### PR TITLE
feat(config): accept "max" as a valid model.thinking level

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ Valid `model.thinking` values are:
 * `medium`
 * `high`
 * `xhigh`
+* `max`
 
 If no `model` is configured, memory workers use the session model.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -69,7 +69,7 @@ You can omit everything. Defaults work for ordinary sessions, and if `model` is 
 | `passive` | boolean | `false` | Disables proactive background memory and auto-compaction triggers. |
 | `debugLog` | boolean | `false` | Writes best-effort per-session extension debug events to Pi's agent directory. |
 
-Valid `model.thinking` values are `off`, `minimal`, `low`, `medium`, `high`, and `xhigh`.
+Valid `model.thinking` values are `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, and `max`.
 
 Invalid values are ignored. Positive-integer settings must be finite integers greater than zero. `observationsPoolTargetTokens` must also be below `observationsPoolMaxTokens`; if omitted or invalid, it is derived as `Math.floor(observationsPoolMaxTokens / 2)`.
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -84,7 +84,7 @@ export function resolveCompactAfterTokens(config: Config, contextWindow: number 
 	return config.compactAfterTokens;
 }
 
-export const THINKING_LEVEL_VALUES: readonly ModelThinkingLevel[] = ["off", "minimal", "low", "medium", "high", "xhigh"] as const;
+export const THINKING_LEVEL_VALUES: readonly ModelThinkingLevel[] = ["off", "minimal", "low", "medium", "high", "xhigh", "max"] as const;
 
 /** Observer chunk cap used when no config is set and the model's context window is unknown. */
 export const OBSERVER_CHUNK_FALLBACK_MAX_TOKENS = 60_000;

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -88,6 +88,18 @@ describe("V3 config", () => {
 		});
 	});
 
+	it("accepts max as a valid model thinking level", () => {
+		writeJson(join(cwd, ".pi", "settings.json"), {
+			"observational-memory": {
+				model: { provider: "anthropic", id: "claude", thinking: "max" },
+			},
+		});
+
+		expect(loadConfig(cwd, {})).toMatchObject({
+			model: { provider: "anthropic", id: "claude", thinking: "max" },
+		});
+	});
+
 	it("ignores invalid V3 values", () => {
 		writeJson(join(cwd, ".pi", "settings.json"), {
 			"observational-memory": {


### PR DESCRIPTION
## Problem

`pi-ai`'s `ThinkingLevel` type includes `"max"` (`"off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max"`), and some providers/models expose `max` as their top reasoning tier (e.g. DeepSeek V4 via OpenCode-compatible gateways, where the upstream accepts exactly `high` and `max`).

The extension's settings validator (`THINKING_LEVEL_VALUES`) only accepts up to `"xhigh"`. A user who configures:

```json
{
  "observational-memory": {
    "model": { "provider": "...", "id": "...", "thinking": "max" }
  }
}
```

gets the `thinking` value **silently ignored**, so memory workers fall back to `"low"` — the opposite of what was requested.

## Change

- Add `"max"` to `THINKING_LEVEL_VALUES` in `src/config.ts` (it is already in the `ModelThinkingLevel` type, and worker agents pass the level through to `AgentLoopConfig.reasoning` unchanged, so no other code changes are needed).
- Update the valid-values list in `README.md` and `docs/configuration.md`.
- Add a config test asserting `"max"` round-trips through `loadConfig`.

## Testing

- `tests/config.test.ts`: 17/17 pass, including the new `max` case.
- Full suite: 214/228 pass; the 14 failures (dropper-pool, status-command, consolidation-trigger, observer) reproduce identically on clean `master` (213/227 without the new test), so they are pre-existing and unrelated to this change.