### PR TITLE
test: update expectations for rendered-line pool token counting

### DIFF
--- a/tests/consolidation-trigger.test.ts
+++ b/tests/consolidation-trigger.test.ts
@@ -296,7 +296,7 @@ describe("V3 consolidation trigger", () => {
 			[expect.stringMatching(/^Observational memory: observer running on ~\d+-token chunk$/), "info"],
 			["Observational memory: 1 observation recorded", "info"],
 			["Observational memory: reflector running (~2 tokens)", "info"],
-			["Observational memory: dropper running after reflection — active observation pool ~10 / 5 target tokens (200%)", "info"],
+			["Observational memory: dropper running after reflection — active observation pool ~19 / 5 target tokens (380%)", "info"],
 		]);
 	});
 

--- a/tests/dropper-pool.test.ts
+++ b/tests/dropper-pool.test.ts
@@ -1,18 +1,21 @@
 import { describe, expect, it } from "vitest";
 
 import { observationPoolMetrics } from "../src/agents/dropper/pool.js";
+import { observationLineTokenCount } from "../src/tokens.js";
 import { foldLedger } from "../src/session-ledger/index.js";
 import { observation, observationsDroppedEntry, observationsRecordedEntry, textCustomMessage } from "./fixtures/session.js";
 
 describe("V3 dropper active observation pool metrics", () => {
 	it("reports below-target pools as not ready", () => {
-		const observations = [observation("aaaaaaaaaaaa", { relevance: "low", tokenCount: 20 })];
+		const observations = [observation("aaaaaaaaaaaa", { relevance: "low" })];
 
+		// Pool metrics count the full rendered line (id + timestamp + relevance + content).
+		expect(observationLineTokenCount(observations[0]!)).toBe(18);
 		expect(observationPoolMetrics(observations, 100)).toMatchObject({
-			observationTokens: 20,
+			observationTokens: 18,
 			targetTokens: 100,
 			tokensOverTarget: 0,
-			fullness: 0.2,
+			fullness: 0.18,
 			activeObservationCount: 1,
 			droppableCount: 1,
 			overTarget: false,
@@ -21,9 +24,10 @@ describe("V3 dropper active observation pool metrics", () => {
 	});
 
 	it("reports at-target pools as not ready", () => {
+		// Pad content so each rendered line is exactly 50 tokens (200 chars).
 		const observations = [
-			observation("aaaaaaaaaaaa", { relevance: "low", tokenCount: 50 }),
-			observation("bbbbbbbbbbbb", { relevance: "medium", tokenCount: 50 }),
+			observation("aaaaaaaaaaaa", { relevance: "low", content: "x".repeat(154) }),
+			observation("bbbbbbbbbbbb", { relevance: "medium", content: "x".repeat(151) }),
 		];
 
 		const metrics = observationPoolMetrics(observations, 100);
@@ -37,10 +41,11 @@ describe("V3 dropper active observation pool metrics", () => {
 	});
 
 	it("reports above-target pools as ready with target-return max drops", () => {
+		// Pad content so each rendered line is exactly 50 tokens (200 chars).
 		const observations = [
-			observation("aaaaaaaaaaaa", { relevance: "low", tokenCount: 50 }),
-			observation("bbbbbbbbbbbb", { relevance: "medium", tokenCount: 50 }),
-			observation("cccccccccccc", { relevance: "critical", tokenCount: 50 }),
+			observation("aaaaaaaaaaaa", { relevance: "low", content: "x".repeat(154) }),
+			observation("bbbbbbbbbbbb", { relevance: "medium", content: "x".repeat(151) }),
+			observation("cccccccccccc", { relevance: "critical", content: "x".repeat(149) }),
 		];
 
 		const metrics = observationPoolMetrics(observations, 100);
@@ -56,20 +61,20 @@ describe("V3 dropper active observation pool metrics", () => {
 
 	it("clamps target-return max drops to active observation count", () => {
 		const observations = [
-			observation("aaaaaaaaaaaa", { relevance: "low", tokenCount: 1 }),
-			observation("bbbbbbbbbbbb", { relevance: "critical", tokenCount: 1 }),
+			observation("aaaaaaaaaaaa", { relevance: "low", content: "x" }),
+			observation("bbbbbbbbbbbb", { relevance: "critical", content: "x" }),
 		];
 
 		const metrics = observationPoolMetrics(observations, 0);
 
-		expect(metrics.tokensOverTarget).toBe(2);
+		expect(metrics.tokensOverTarget).toBe(25);
 		expect(metrics.maxDropsAllowed).toBe(2);
 		expect(metrics.ready).toBe(true);
 	});
 
 	it("uses folded active observations so tombstones reduce readiness", () => {
-		const dropped = observation("aaaaaaaaaaaa", { relevance: "low", tokenCount: 100 });
-		const active = observation("bbbbbbbbbbbb", { relevance: "low", tokenCount: 20 });
+		const dropped = observation("aaaaaaaaaaaa", { relevance: "low" });
+		const active = observation("bbbbbbbbbbbb", { relevance: "low" });
 		const entries = [
 			textCustomMessage("raw-1", "aaaaaaaa"),
 			observationsRecordedEntry("om-obs", { observations: [dropped, active], coversUpToId: "raw-1" }),
@@ -80,7 +85,7 @@ describe("V3 dropper active observation pool metrics", () => {
 		const metrics = observationPoolMetrics(folded.activeObservations, 100);
 
 		expect(folded.activeObservations.map((obs) => obs.id)).toEqual(["bbbbbbbbbbbb"]);
-		expect(metrics.observationTokens).toBe(20);
+		expect(metrics.observationTokens).toBe(18);
 		expect(metrics.overTarget).toBe(false);
 		expect(metrics.ready).toBe(false);
 	});

--- a/tests/dropper.test.ts
+++ b/tests/dropper.test.ts
@@ -99,11 +99,12 @@ describe("V3 dropper agent", () => {
 
 		await runDropper({ ...baseArgs, agentLoop: loop });
 
-		expect(userText).toContain("fullness against target: ~150%");
-		expect(userText).toContain("over target by ~10 tokens");
+		// Pool metrics count full rendered lines: 19 + 18 + 19 = 56 tokens against a 20-token target.
+		expect(userText).toContain("fullness against target: ~280%");
+		expect(userText).toContain("over target by ~36 tokens");
 		expect(userText).toContain("[coverage: partial]");
 		expect(userText).toContain("[coverage: none]");
-		expect(userText).toContain("Maximum drops allowed this run: 1 observation");
+		expect(userText).toContain("Maximum drops allowed this run: 2 observations");
 		expect(userText).toContain("sized to move the active pool toward the target");
 		expect(userText).toContain("hard upper bound, not a target");
 		expect(userText).toContain("Drop fewer or none");
@@ -171,7 +172,8 @@ describe("V3 dropper agent", () => {
 			await context.tools[0].execute("tool-1", { ids: ["aaaaaaaaaaaa", "missing", "bbbbbbbbbbbb"] });
 		});
 
-		await expect(runDropper({ ...baseArgs, agentLoop: loop })).resolves.toEqual(["aaaaaaaaaaaa"]);
+		// Rendered-line pool is 56 tokens; a 40-token target caps the run at 1 drop.
+		await expect(runDropper({ ...baseArgs, targetTokens: 40, agentLoop: loop })).resolves.toEqual(["aaaaaaaaaaaa"]);
 	});
 
 	it("returns critical proposed ids when they are the selected valid candidates", async () => {
@@ -196,7 +198,8 @@ describe("V3 dropper agent", () => {
 			await context.tools[0].execute("tool-2", { ids: ["bbbbbbbbbbbb", "aaaaaaaaaaaa"] });
 		});
 
-		await expect(runDropper({ ...baseArgs, agentLoop: loop })).resolves.toEqual(["aaaaaaaaaaaa"]);
+		// Rendered-line pool is 56 tokens; a 40-token target caps the run at 1 drop.
+		await expect(runDropper({ ...baseArgs, targetTokens: 40, agentLoop: loop })).resolves.toEqual(["aaaaaaaaaaaa"]);
 	});
 
 	it("returns undefined when no tool call drops observations", async () => {
@@ -212,8 +215,9 @@ describe("V3 dropper agent", () => {
 
 		await expect(runDropper({
 			...baseArgs,
-			observations: [observation("aaaaaaaaaaaa", { relevance: "low", tokenCount: 10 })],
-			targetTokens: 10,
+			// The rendered line for this observation is 18 tokens; an 18-token target is exactly at target.
+			observations: [observation("aaaaaaaaaaaa", { relevance: "low" })],
+			targetTokens: 18,
 			agentLoop: loop,
 		})).resolves.toBeUndefined();
 		expect(called).toBe(false);

--- a/tests/observer.test.ts
+++ b/tests/observer.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 
 import { normalizeSourceEntryIds, OBSERVATION_TIMESTAMP_PATTERN, ObserverStreamError, runObserver } from "../src/agents/observer/agent.js";
-import { estimateStringTokens } from "../src/tokens.js";
 
 function fakeAgentLoop(handler: (prompts: any[], context: any, config: any) => Promise<void> | void, events: any[] = []): any {
 	return ((prompts: any[], context: any, config: any) => ({
@@ -75,7 +74,8 @@ describe("runObserver", () => {
 			timestamp: "2026-05-02 10:30",
 			relevance: "high",
 			sourceEntryIds: ["entry-a"],
-			tokenCount: estimateStringTokens(content),
+			// tokenCount is code-computed from the full rendered line (id + timestamp + relevance + content).
+			tokenCount: 18,
 		});
 		expect(observations?.[0].id).toMatch(/^[a-f0-9]{12}$/);
 	});

--- a/tests/status-command.test.ts
+++ b/tests/status-command.test.ts
@@ -87,7 +87,8 @@ describe("V3 /om:status", () => {
 		expect(output).toContain("Observations: 2 recorded / 1 dropped / 1 active / 1 visible +1 -1");
 		expect(output).toContain("Reflections:  1 recorded / 0 visible +1");
 		expect(output).toContain("Visible observation pool: ~5 / 40 tokens (13%)");
-		expect(output).toContain("Active observation pool: ~7 / 20 target tokens (35%)");
+		// Active pool counts the full rendered line (id + timestamp + relevance + content).
+		expect(output).toContain("Active observation pool: ~19 / 20 target tokens (95%)");
 		expect(output).not.toContain("Visible:");
 		expect(output).not.toContain("Drift:");
 		expect(output).not.toContain("full truth");
@@ -115,7 +116,8 @@ describe("V3 /om:status", () => {
 		expect(output).toContain("Next compaction:");
 		expect(output).toContain("/ 30 tokens");
 		expect(output).toContain("Visible observation pool: ~5 / 40 tokens (13%)");
-		expect(output).toContain("Active observation pool: ~5 / 20 target tokens (25%)");
+		// Active pool counts the full rendered line, unlike the visible pool's stored tokenCount.
+		expect(output).toContain("Active observation pool: ~19 / 20 target tokens (95%)");
 		expect(output).toContain("Reflection pool:         ~3 tokens");
 		expect(output).not.toContain("Observation pool:");
 		expect(output).not.toContain("Full fold pool:");
@@ -123,7 +125,8 @@ describe("V3 /om:status", () => {
 	});
 
 	it("shows over-target active observation pool in the Activity section", async () => {
-		const obs = observation("aaaaaaaaaaaa", { tokenCount: 25 });
+		// Pad content so the rendered line is exactly 25 tokens (100 chars).
+		const obs = observation("aaaaaaaaaaaa", { content: "x".repeat(51) });
 		const entries = [
 			textCustomMessage("raw-1", "aaaaaaaa"),
 			observationsRecordedEntry("om-obs", { observations: [obs], coversUpToId: "raw-1" }),


### PR DESCRIPTION
## Problem

PR #40 (64f3f8c, "measure token thresholds on real provider usage") intentionally changed token accounting:

- dropper pool metrics sum **full rendered lines** (`[id] timestamp [relevance] content`) via `observationLineTokenCount` instead of bare `tokenCount`
- observer-recorded `tokenCount` is computed from the rendered line as well

The commit did not update the affected tests, so **master currently has 14 failing tests** across 5 files (`dropper-pool`, `status-command`, `dropper`, `consolidation-trigger`, `observer`). Since the CI workflow only runs on version tags, nothing surfaces this.

## Change

Test-only updates that align expectations with the new (correct) semantics:

- **dropper-pool**: pad fixture content so rendered lines hit the intended token sizes (50 tokens/line, preserving the original at/above-target scenarios); update expected sums and fullness
- **status-command**: active observation pool now reflects rendered lines (`~19 / 20`, 95%) while the visible pool keeps the stored `tokenCount` — the divergent values actually exercise the two-pool distinction better than before
- **dropper**: update pool summary text (`~56` tokens, `~280%`, max 2 drops); raise `targetTokens` to 40 where tests intend a run-level cap of 1; use an 18-token target for the exact at-target boundary
- **consolidation-trigger**: update routine dropper notification text
- **observer**: `tokenCount` expectation follows rendered-line computation (18)

No source changes. Each updated expectation was recomputed from the new semantics rather than copied from failure output.

## Testing

`npx vitest run`: **227/227 passing** (was 213/227 on master).