### PR TITLE
fix: anchor compaction to provider context growth

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,9 +230,8 @@ Most users can start with the defaults and tune only if they have a specific rea
 ### Scaling compaction to the model's context window
 
 By default `compactAfterTokensMode` is `"calibrated"`, so the proactive
-compaction trigger fires at the fixed `compactAfterTokens` value (81,000 by
-default). That is backwards-compatible and works well for typical ~128K–200K
-context models.
+compaction trigger uses the fixed `compactAfterTokens` growth threshold (81,000
+by default). This works well for typical ~128K–200K context models.
 
 On a large-context model (e.g. 1M tokens) the calibrated default preempts
 compaction at ~81K, wasting most of the window. Switch to `"ratio"` mode to let
@@ -250,8 +249,11 @@ the trigger scale with the active model's `contextWindow`:
 
 In ratio mode the effective threshold is
 `floor(model.contextWindow * compactAfterTokensRatio)` (clamped to a minimum of
-1). With the example above, a 1,000,000-token window compacts at ~500,000 raw
-tokens; a 200,000-token window compacts at ~100,000.
+1). With the example above, a 1,000,000-token window compacts after about
+500,000 tokens of provider context growth since the latest successful
+compaction; a 200,000-token window uses about 100,000. Retained summaries and
+kept messages are not counted again. If Pi cannot provide a comparable count,
+the extension uses estimated source-token progress.
 
 `compactAfterTokensRatio` is user-tunable precisely because **context window ≠
 attention**. Some models advertise a large window but degrade at long range; set
@@ -271,8 +273,8 @@ on the `Next compaction` line regardless of mode.
 | `observeAfterTokens`        | `10000`       | Raw/source token threshold for observation runs.                                                  |
 | `observerChunkMaxTokens`    | derived       | Max estimated tokens serialized into one observer chunk (minimum `256`). Unset: `floor(contextWindow * 0.2)` of the resolved memory model, or `60000` when the window is unknown. Larger backlogs drain oldest-first; a single over-budget source is sent as a marked head/tail excerpt while the original source remains in the session ledger. |
 | `reflectAfterTokens`        | `20000`       | Raw/source token threshold for reflection runs; successful reflection creates dropper opportunities. |
-| `compactAfterTokens`        | `81000`       | Raw/source token threshold for proactive auto-compaction (used directly in `"calibrated"` mode, and as the fallback in `"ratio"` mode). |
-| `compactAfterTokensMode`    | `"calibrated"`| `"calibrated"` uses `compactAfterTokens` directly (default, backwards-compatible). `"ratio"` scales the threshold by the active model's `contextWindow`. |
+| `compactAfterTokens`        | `81000`       | Provider context-growth threshold for proactive auto-compaction (used directly in `"calibrated"` mode, and as the fallback in `"ratio"` mode). The raw source-token estimate is used when provider usage is unavailable or incomparable. |
+| `compactAfterTokensMode`    | `"calibrated"`| `"calibrated"` uses `compactAfterTokens` directly. The threshold measures provider context growth, with estimated source progress as a fallback. `"ratio"` scales the threshold by the active model's `contextWindow`. |
 | `compactAfterTokensRatio`   | `0.68`        | In `"ratio"` mode, the threshold is `floor(contextWindow * ratio)`. Tunable because large windows do not always mean strong long-range attention. Must be in `(0, 1)`. |
 | `observationsPoolMaxTokens` | `20000`       | Observation-token budget used for compaction full-fold pressure.                                  |
 | `observationsPoolTargetTokens` | half of max | Active observation target used by post-reflection dropper maintenance.                            |
@@ -345,6 +347,14 @@ The high-level lifecycle:
 5. The agent continues with a compact but useful view of the work so far.
 
 The important part: compaction does not need to rethink the whole session from scratch.
+
+The proactive compaction threshold measures provider context growth after the
+latest successful compaction. The first valid assistant usage after compaction
+sets the baseline. If Pi reports unknown usage, or a model/provider change makes
+the baseline incomparable, the extension falls back to estimated source-token
+progress. After a model/provider change, that fallback remains until a later
+successful compaction creates a new provider baseline. `/om:status` labels which
+metric it uses. Pi's own window-pressure compaction remains independent.
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -57,7 +57,7 @@ You can omit everything. Defaults work for ordinary sessions, and if `model` is 
 | `observeAfterTokens` | positive integer | `10000` | Raw/source token threshold for observer runs. |
 | `reflectAfterTokens` | positive integer | `20000` | Raw/source token threshold for reflector runs; successful reflection creates dropper maintenance opportunities. |
 | `observerChunkMaxTokens` | positive integer | derived; minimum `256` | Maximum estimated tokens sent to one observer run. Unset: 20% of the resolved memory model's context window, or `60000` when unknown. |
-| `compactAfterTokens` | positive integer | `81000` | Raw/source token threshold for proactive auto-compaction. |
+| `compactAfterTokens` | positive integer | `81000` | Provider context-growth threshold for proactive auto-compaction. The raw source-token estimate is the fallback when provider usage is unavailable or incomparable. |
 | `observationsPoolMaxTokens` | positive integer | `20000` | Normal compaction-projection observation-token pressure that makes compaction do a full fold. |
 | `observationsPoolTargetTokens` | positive integer below max | half of `observationsPoolMaxTokens` | Folded active observation target used by post-reflection dropper maintenance. |
 | `agentMaxTurns` | positive integer | `16` | Shared nested-agent turn cap for observer, reflector, and dropper. |
@@ -103,7 +103,7 @@ Lower values distill reflections more often and therefore create more opportunit
 
 Default: `81000`.
 
-The auto-compaction trigger runs from Pi's `agent_end` hook. It counts raw/source tokens after the latest compaction boundary. If the count reaches `compactAfterTokens`, the extension defers with `setTimeout(0)`, checks that Pi is idle, re-checks the threshold, and calls `ctx.compact()`.
+The auto-compaction trigger runs from Pi's `agent_end` hook. It counts provider context growth after the latest successful compaction. The first valid assistant usage after compaction sets the baseline. If Pi reports unknown usage, or a model/provider change makes the baseline incomparable, the extension uses estimated source-token progress after the compaction boundary. After a model/provider change, that fallback remains until a later successful compaction creates a new provider baseline. If the count reaches `compactAfterTokens`, the extension defers with `setTimeout(0)`, checks that Pi is idle, re-checks the same metric, and calls `ctx.compact()`.
 
 This trigger does not wait for observer, reflector, or dropper work. Actual compaction summary creation happens later in `session_before_compact`, where V3 compaction is deterministic and model-free.
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -204,11 +204,12 @@ It skips when:
 - `passive` is true;
 - compaction is already in flight;
 - the agent end event is a retryable error;
-- raw/source tokens since last compaction are below `compactAfterTokens`;
+- provider context growth since the latest successful compaction is below `compactAfterTokens`;
+- the provider baseline is unavailable or incomparable and estimated source progress is below `compactAfterTokens`;
 - Pi is not idle after the deferred check;
 - the threshold is no longer met after the deferred check.
 
-When all checks pass, it calls `ctx.compact()`.
+The provider baseline uses the first valid assistant usage after compaction. A model/provider change after that baseline causes fallback to estimated source progress until a later successful compaction creates a new provider baseline. When all checks pass, it calls `ctx.compact()`.
 
 This trigger does not wait for observer, reflector, or dropper promises. That is intentional: background memory work should never make compaction feel stuck.
 

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -6,7 +6,7 @@ import {
 	diffProjection,
 	foldLedger,
 	fullProjection,
-	rawTokensSinceLastCompaction,
+	compactionProgress,
 	rawTokensSinceObservationCoverage,
 	rawTokensSinceReflectionCoverage,
 	visibleProjection,
@@ -61,9 +61,13 @@ export function registerStatusCommand(pi: ExtensionAPI, runtime: Runtime): void 
 			);
 			const obsProgress = rawTokensSinceObservationCoverage(entries);
 			const reflectionProgress = rawTokensSinceReflectionCoverage(entries);
-			const compactionProgress = rawTokensSinceLastCompaction(entries);
-			const contextWindow = typeof ctx.model?.contextWindow === "number" ? ctx.model.contextWindow : undefined;
+			const contextUsage = typeof ctx.getContextUsage === "function" ? ctx.getContextUsage() : undefined;
+			const compaction = compactionProgress(entries, contextUsage?.tokens);
+			const contextWindow =
+				contextUsage?.contextWindow
+				?? (typeof ctx.model?.contextWindow === "number" ? ctx.model.contextWindow : undefined);
 			const compactThreshold = resolveCompactAfterTokens(runtime.config, contextWindow);
+			const compactionMetricLabel = compaction.source === "provider" ? "provider context growth" : "estimated source";
 
 			const passiveLines = runtime.config.passive === true
 				? [
@@ -82,7 +86,7 @@ export function registerStatusCommand(pi: ExtensionAPI, runtime: Runtime): void 
 				"── Activity ──",
 				`Next observation: ~${obsProgress.toLocaleString()} / ${runtime.config.observeAfterTokens.toLocaleString()} tokens (${pct(obsProgress, runtime.config.observeAfterTokens)}%)`,
 				`Next reflection:  ~${reflectionProgress.toLocaleString()} / ${runtime.config.reflectAfterTokens.toLocaleString()} tokens (${pct(reflectionProgress, runtime.config.reflectAfterTokens)}%)`,
-				`Next compaction:  ~${compactionProgress.toLocaleString()} / ${compactThreshold.toLocaleString()} tokens (${pct(compactionProgress, compactThreshold)}%)`,
+				`Next compaction:  ~${compaction.tokens.toLocaleString()} / ${compactThreshold.toLocaleString()} ${compactionMetricLabel} tokens (${pct(compaction.tokens, compactThreshold)}%)`,
 				`Visible observation pool: ~${visibleObservationTokens.toLocaleString()} / ${runtime.config.observationsPoolMaxTokens.toLocaleString()} tokens (${pct(visibleObservationTokens, runtime.config.observationsPoolMaxTokens)}%)`,
 				`Active observation pool: ~${activeObservationPool.observationTokens.toLocaleString()} / ${runtime.config.observationsPoolTargetTokens.toLocaleString()} target tokens (${pct(activeObservationPool.observationTokens, runtime.config.observationsPoolTargetTokens)}%)`,
 				`Reflection pool:         ~${visibleReflectionTokens.toLocaleString()} tokens`,

--- a/src/hooks/compaction-trigger.ts
+++ b/src/hooks/compaction-trigger.ts
@@ -1,6 +1,6 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { resolveCompactAfterTokens } from "../config.js";
-import { rawTokensSinceLastCompaction, type Entry } from "../session-ledger/index.js";
+import { compactionProgress, type Entry } from "../session-ledger/index.js";
 import type { Runtime } from "../runtime.js";
 
 /**
@@ -32,41 +32,24 @@ export function registerCompactionTrigger(pi: ExtensionAPI, runtime: Runtime): v
 			return;
 		}
 
-		// Use the session's REAL context usage (provider-reported tokens) instead of a
-		// client-side token estimate. The old raw-token estimate systematically
-		// undercounted the live context — it omitted the system prompt, tool schemas,
-		// thinking/reasoning tokens, and drifted from the provider's own accounting by
-		// ~20-46% in practice. The trigger could therefore lag the visible footer
-		// context percentage badly (e.g. UI at 36% while the estimate sat below a
-		// 0.35 × window threshold), so compaction never fired in long sessions.
-		// ctx.getContextUsage() reports the same basis the footer percentage uses.
+		const entries = ctx.sessionManager?.getBranch?.() as Entry[] | undefined;
+		if (!entries) return;
 		const contextUsage = typeof ctx.getContextUsage === "function" ? ctx.getContextUsage() : undefined;
-		let tokens = contextUsage?.tokens;
-		if (typeof tokens !== "number" || !Number.isFinite(tokens)) {
-			// getContextUsage is unavailable on older pi hosts, or context is unknown
-			// until the next valid assistant response. Fall back to the raw
-			// source-entry estimate so the trigger still works on older pi versions.
-			const entries = ctx.sessionManager?.getBranch?.() as Entry[] | undefined;
-			if (!entries) return;
-			tokens = rawTokensSinceLastCompaction(entries);
-			if (typeof tokens !== "number") return;
-		}
-		// Resolve the proactive-compaction threshold from the active model's context
-		// window when ratio mode is configured. Prefer the window reported by
-		// getContextUsage(); fall back to ctx.model (Model<any> | undefined).
+		const progress = compactionProgress(entries, contextUsage?.tokens);
 		const contextWindow =
 			contextUsage?.contextWindow
 			?? (typeof ctx.model?.contextWindow === "number" ? ctx.model.contextWindow : undefined);
 		const threshold = resolveCompactAfterTokens(runtime.config, contextWindow);
-		if (tokens < threshold) return;
+		if (progress.tokens < threshold) return;
 
 		// Capture ctx properties synchronously — the setTimeout + async work below
 		// may outlive the extension ctx (stale after session replacement/reload).
 		const hasUI = ctx.hasUI;
 		const ui = ctx.ui;
 
+		const progressLabel = progress.source === "provider" ? "provider context growth" : "estimated source";
 		if (hasUI) ui?.notify(
-			`Observational memory: compaction threshold reached (~${tokens.toLocaleString()} tokens); triggering compaction`,
+			`Observational memory: compaction threshold reached (~${progress.tokens.toLocaleString()} ${progressLabel} tokens); triggering compaction`,
 			"info",
 		);
 
@@ -81,17 +64,14 @@ export function registerCompactionTrigger(pi: ExtensionAPI, runtime: Runtime): v
 					);
 					return;
 				}
-				const currentUsage = typeof ctx.getContextUsage === "function" ? ctx.getContextUsage() : undefined;
-				let currentTokens = currentUsage?.tokens;
-				if (typeof currentTokens !== "number") {
-					const currentEntries = ctx.sessionManager?.getBranch?.() as Entry[] | undefined;
-					if (!currentEntries) {
-						runtime.compactInFlight = false;
-						return;
-					}
-					currentTokens = rawTokensSinceLastCompaction(currentEntries);
+				const currentEntries = ctx.sessionManager?.getBranch?.() as Entry[] | undefined;
+				if (!currentEntries) {
+					runtime.compactInFlight = false;
+					return;
 				}
-				if (typeof currentTokens !== "number" || currentTokens < threshold) {
+				const currentUsage = typeof ctx.getContextUsage === "function" ? ctx.getContextUsage() : undefined;
+				const currentProgress = compactionProgress(currentEntries, currentUsage?.tokens);
+				if (currentProgress.tokens < threshold) {
 					runtime.compactInFlight = false;
 					if (hasUI) ui?.notify(
 						"Observational memory: compaction skipped — another compaction already ran before deferred compaction",

--- a/src/session-ledger/progress.ts
+++ b/src/session-ledger/progress.ts
@@ -176,6 +176,18 @@ export function realContextTokensAfterCompaction(entries: Entry[], compactionIdx
 	return undefined;
 }
 
+function hasModelChangeAfterCompactionBaseline(entries: Entry[], compactionIdx: number): boolean {
+	let baselineFound = false;
+	for (let i = compactionIdx + 1; i < entries.length; i++) {
+		if (!baselineFound && validAssistantContextTokens(entries[i]) !== undefined) {
+			baselineFound = true;
+			continue;
+		}
+		if (baselineFound && entries[i].type === "model_change") return true;
+	}
+	return false;
+}
+
 /**
  * Real context tokens at the time observation coverage ended: last valid
  * assistant usage at/before the covered entry. Returns undefined when no valid
@@ -233,4 +245,30 @@ export function rawTokensSinceLastCompaction(entries: Entry[]): number {
 
 	if (firstKeptIndex === -1) return rawTokensAfterIndex(entries, compactionIndex);
 	return rawTokensAfterIndex(entries, firstKeptIndex - 1);
+}
+
+export type CompactionProgress = {
+	tokens: number;
+	source: "provider" | "raw";
+};
+
+/**
+ * Returns context growth since the latest successful compaction when Pi's
+ * provider usage is comparable. Raw source-token progress is the safe fallback.
+ */
+export function compactionProgress(entries: Entry[], currentContextTokens: number | null | undefined): CompactionProgress {
+	const raw = rawTokensSinceLastCompaction(entries);
+	if (typeof currentContextTokens !== "number" || !Number.isFinite(currentContextTokens)) {
+		return { tokens: raw, source: "raw" };
+	}
+
+	const compactionIdx = findLastCompactionIndex(entries);
+	if (compactionIdx >= 0 && hasModelChangeAfterCompactionBaseline(entries, compactionIdx)) {
+		return { tokens: raw, source: "raw" };
+	}
+
+	const real = realTokensSinceAnchor(entries, undefined, currentContextTokens);
+	return real === undefined
+		? { tokens: raw, source: "raw" }
+		: { tokens: real, source: "provider" };
 }

--- a/tests/compaction-trigger.test.ts
+++ b/tests/compaction-trigger.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { registerCompactionTrigger } from "../src/hooks/compaction-trigger.js";
-import { compactionEntry, textCustomMessage, type TestEntry } from "./fixtures/session.js";
+import { compactionEntry, rawMessage, textCustomMessage, type TestEntry } from "./fixtures/session.js";
 
 function captureHandler(args: { compactAfterTokens?: number; compactAfterTokensMode?: "calibrated" | "ratio"; compactAfterTokensRatio?: number; passive?: boolean; compactInFlight?: boolean } = {}) {
 	let handler: ((event: unknown, ctx: unknown) => void) | undefined;
@@ -88,7 +88,7 @@ describe("V3 compaction trigger", () => {
 
 		expect(ctx.compact).toHaveBeenCalledTimes(1);
 		expect(ctx.ui.notify).toHaveBeenCalledWith(
-			"Observational memory: compaction threshold reached (~3 tokens); triggering compaction",
+			"Observational memory: compaction threshold reached (~3 estimated source tokens); triggering compaction",
 			"info",
 		);
 	});
@@ -184,6 +184,110 @@ describe("V3 compaction trigger", () => {
 		expect(ctx.compact).toHaveBeenCalledTimes(1);
 	});
 
+	it("does not compact when full context exceeds the threshold but anchored growth does not", async () => {
+		const { handler, runtime } = captureHandler({ compactAfterTokens: 130000 });
+		const branch = [
+			compactionEntry("cmp-1"),
+			rawMessage("assistant-1", "done", {
+				message: { role: "assistant", content: "done", stopReason: "end_turn", usage: { totalTokens: 60072 } },
+			}),
+			textCustomMessage("raw-1", "small"),
+		];
+		const ctx = fakeCtx([branch], {
+			getContextUsage: vi.fn(() => ({ tokens: 135636, contextWindow: 200000 })),
+		});
+
+		handler(agentEnd(), ctx);
+		await vi.runAllTimersAsync();
+
+		expect(ctx.compact).not.toHaveBeenCalled();
+		expect(runtime.compactInFlight).toBe(false);
+	});
+
+	it("uses provider context from zero before the first compaction", async () => {
+		const { handler } = captureHandler({ compactAfterTokens: 130000 });
+		const ctx = fakeCtx([dueBranch], {
+			getContextUsage: vi.fn(() => ({ tokens: 130000, contextWindow: 200000 })),
+		});
+
+		handler(agentEnd(), ctx);
+		await vi.runAllTimersAsync();
+
+		expect(ctx.compact).toHaveBeenCalledTimes(1);
+	});
+
+	it("compacts when anchored provider growth equals the threshold", async () => {
+		const { handler } = captureHandler({ compactAfterTokens: 130000 });
+		const branch = [
+			compactionEntry("cmp-1"),
+			rawMessage("assistant-1", "done", {
+				message: { role: "assistant", content: "done", stopReason: "end_turn", usage: { totalTokens: 60000 } },
+			}),
+		];
+		const ctx = fakeCtx([branch], {
+			getContextUsage: vi.fn(() => ({ tokens: 190000, contextWindow: 200000 })),
+		});
+
+		handler(agentEnd(), ctx);
+		await vi.runAllTimersAsync();
+
+		expect(ctx.compact).toHaveBeenCalledTimes(1);
+	});
+
+	it("uses raw progress when provider usage is unknown or has no baseline", async () => {
+		const { handler } = captureHandler({ compactAfterTokens: 3 });
+		const branch = [compactionEntry("cmp-1"), textCustomMessage("raw-1", "aaaa")];
+		const ctx = fakeCtx([branch], {
+			getContextUsage: vi.fn(() => ({ tokens: null, contextWindow: 200000 })),
+		});
+
+		handler(agentEnd(), ctx);
+		await vi.runAllTimersAsync();
+
+		expect(ctx.compact).not.toHaveBeenCalled();
+	});
+
+	it("rechecks anchored growth after deferral", async () => {
+		const { handler, runtime } = captureHandler({ compactAfterTokens: 130000 });
+		const branch = [
+			compactionEntry("cmp-1"),
+			rawMessage("assistant-1", "done", {
+				message: { role: "assistant", content: "done", stopReason: "end_turn", usage: { totalTokens: 60000 } },
+			}),
+		];
+		const ctx = fakeCtx([branch], {
+			getContextUsage: vi.fn()
+				.mockReturnValueOnce({ tokens: 190000, contextWindow: 200000 })
+				.mockReturnValueOnce({ tokens: 120000, contextWindow: 200000 }),
+		});
+
+		handler(agentEnd(), ctx);
+		await vi.runAllTimersAsync();
+
+		expect(ctx.compact).not.toHaveBeenCalled();
+		expect(runtime.compactInFlight).toBe(false);
+	});
+
+	it("falls back to raw progress after a model change", async () => {
+		const { handler } = captureHandler({ compactAfterTokens: 3 });
+		const branch = [
+			compactionEntry("cmp-1"),
+			rawMessage("assistant-1", "done", {
+				message: { role: "assistant", content: "done", stopReason: "end_turn", usage: { totalTokens: 60000 } },
+			}),
+			{ type: "model_change", id: "model-1", timestamp: "2026-05-02T10:00:00.000Z" },
+			textCustomMessage("raw-1", "aaaa"),
+		];
+		const ctx = fakeCtx([branch], {
+			getContextUsage: vi.fn(() => ({ tokens: 190000, contextWindow: 200000 })),
+		});
+
+		handler(agentEnd(), ctx);
+		await vi.runAllTimersAsync();
+
+		expect(ctx.compact).not.toHaveBeenCalled();
+	});
+
 	describe("ratio mode", () => {
 		it("scales the compaction threshold by model.contextWindow", async () => {
 			// 3 tokens raw; ratio 0.5 of 4-token window = 2 -> threshold 2, so 3 >= 2 fires.
@@ -208,6 +312,23 @@ describe("V3 compaction trigger", () => {
 				compactAfterTokensRatio: 0.5,
 			});
 			const ctx = fakeCtx([belowBranch], { model: { contextWindow: 4 } });
+
+			handler(agentEnd(), ctx);
+			await vi.runAllTimersAsync();
+
+			expect(ctx.compact).not.toHaveBeenCalled();
+		});
+
+		it("prefers the provider context window in ratio mode", async () => {
+			const { handler } = captureHandler({
+				compactAfterTokens: 81000,
+				compactAfterTokensMode: "ratio",
+				compactAfterTokensRatio: 0.5,
+			});
+			const ctx = fakeCtx([dueBranch], {
+				model: { contextWindow: 4 },
+				getContextUsage: vi.fn(() => ({ tokens: 2, contextWindow: 10 })),
+			});
 
 			handler(agentEnd(), ctx);
 			await vi.runAllTimersAsync();

--- a/tests/session-ledger-progress.test.ts
+++ b/tests/session-ledger-progress.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+	compactionProgress,
 	earlierCoverageMarkerId,
 	entryIndexById,
 	isSourceEntry,
@@ -18,6 +19,7 @@ import {
 	V3_REFLECTIONS_RECORDED,
 	branchSummary,
 	compactionEntry,
+	rawMessage,
 	observation,
 	observationsDroppedEntry,
 	observationsRecordedEntry,
@@ -139,5 +141,38 @@ describe("session-ledger V3 progress helpers", () => {
 		];
 
 		expect(rawTokensSinceLastCompaction(entries)).toBe(3); // raw-1 + raw-2 from live tail starting at firstKeptEntryId
+	});
+
+	it("uses provider context growth after compaction", () => {
+		const entries = [
+			compactionEntry("cmp-1"),
+			rawMessage("assistant-1", "done", {
+				message: { role: "assistant", content: "done", stopReason: "end_turn", usage: { totalTokens: 60072 } },
+			}),
+		];
+
+		expect(compactionProgress(entries, 135636)).toEqual({ tokens: 75564, source: "provider" });
+	});
+
+	it("falls back to raw progress when provider usage has no post-compaction baseline", () => {
+		const entries = [
+			compactionEntry("cmp-1"),
+			textCustomMessage("raw-1", "aaaaaaaa"),
+		];
+
+		expect(compactionProgress(entries, 135636)).toEqual({ tokens: 2, source: "raw" });
+	});
+
+	it("falls back to raw progress after a model change", () => {
+		const entries = [
+			compactionEntry("cmp-1"),
+			rawMessage("assistant-1", "done", {
+				message: { role: "assistant", content: "done", stopReason: "end_turn", usage: { totalTokens: 60072 } },
+			}),
+			{ type: "model_change", id: "model-1", timestamp: "2026-05-02T10:00:00.000Z" },
+			textCustomMessage("raw-1", "aaaaaaaa"),
+		];
+
+		expect(compactionProgress(entries, 135636)).toEqual({ tokens: 2, source: "raw" });
 	});
 });

--- a/tests/status-command.test.ts
+++ b/tests/status-command.test.ts
@@ -11,11 +11,12 @@ import {
 	oldV2ObservationEntry,
 	reflection,
 	reflectionsRecordedEntry,
+	rawMessage,
 	textCustomMessage,
 	type TestEntry,
 } from "./fixtures/session.js";
 
-function setup(args: { entries: TestEntry[]; runtime?: Partial<any>; model?: unknown }) {
+function setup(args: { entries: TestEntry[]; runtime?: Partial<any>; model?: unknown; contextUsage?: unknown }) {
 	let handler: ((args: unknown, ctx: any) => Promise<void>) | undefined;
 	const pi = {
 		registerCommand: vi.fn((name: string, command: { handler: typeof handler }) => {
@@ -45,7 +46,13 @@ function setup(args: { entries: TestEntry[]; runtime?: Partial<any>; model?: unk
 	registerStatusCommand(pi as any, runtime as any);
 	if (!handler) throw new Error("status handler not registered");
 	const notify = vi.fn();
-	const ctx = { cwd: "/tmp/project", ui: { notify }, sessionManager: { getBranch: () => args.entries }, model: args.model };
+	const ctx = {
+		cwd: "/tmp/project",
+		ui: { notify },
+		sessionManager: { getBranch: () => args.entries },
+		model: args.model,
+		getContextUsage: () => args.contextUsage,
+	};
 	const run = async () => {
 		await handler!(undefined, ctx);
 		return notify.mock.calls.at(-1)?.[0] as string;
@@ -114,7 +121,7 @@ describe("V3 /om:status", () => {
 		expect(output).toContain("Next reflection:");
 		expect(output).toContain("/ 20 tokens");
 		expect(output).toContain("Next compaction:");
-		expect(output).toContain("/ 30 tokens");
+		expect(output).toContain("/ 30 estimated source tokens");
 		expect(output).toContain("Visible observation pool: ~5 / 40 tokens (13%)");
 		// Active pool counts the full rendered line, unlike the visible pool's stored tokenCount.
 		expect(output).toContain("Active observation pool: ~19 / 20 target tokens (95%)");
@@ -122,6 +129,22 @@ describe("V3 /om:status", () => {
 		expect(output).not.toContain("Observation pool:");
 		expect(output).not.toContain("Full fold pool:");
 		expect(output).not.toContain("visible observation tokens");
+	});
+
+	it("shows provider context growth since compaction", async () => {
+		const entries = [
+			compactionEntry("cmp-1"),
+			rawMessage("assistant-1", "done", {
+				message: { role: "assistant", content: "done", stopReason: "end_turn", usage: { totalTokens: 60072 } },
+			}),
+		];
+
+		const output = await setup({
+			entries,
+			contextUsage: { tokens: 135636, contextWindow: 200000 },
+		}).run();
+
+		expect(output).toContain("Next compaction:  ~75,564 / 30 provider context growth tokens");
 	});
 
 	it("shows over-target active observation pool in the Activity section", async () => {
@@ -187,9 +210,32 @@ describe("V3 /om:status", () => {
 					},
 				},
 				model: { contextWindow: 1_000_000 },
+				contextUsage: { tokens: null, contextWindow: 1_000_000 },
 			}).run();
 
-			expect(output).toContain("Next compaction:  ~0 / 500,000 tokens (0%)");
+			expect(output).toContain("Next compaction:  ~0 / 500,000 estimated source tokens (0%)");
+		});
+
+		it("prefers provider contextWindow over model contextWindow in ratio mode", async () => {
+			const output = await setup({
+				entries: [],
+				runtime: {
+					config: {
+						observeAfterTokens: 10,
+						reflectAfterTokens: 20,
+						compactAfterTokens: 30,
+						compactAfterTokensMode: "ratio",
+						compactAfterTokensRatio: 0.5,
+						observationsPoolMaxTokens: 40,
+						observationsPoolTargetTokens: 20,
+						passive: false,
+					},
+				},
+				model: { contextWindow: 100_000 },
+				contextUsage: { tokens: null, contextWindow: 200_000 },
+			}).run();
+
+			expect(output).toContain("Next compaction:  ~0 / 100,000 estimated source tokens (0%)");
 		});
 
 		it("falls back to calibrated threshold when model is unavailable in ratio mode", async () => {
@@ -210,7 +256,7 @@ describe("V3 /om:status", () => {
 				model: undefined,
 			}).run();
 
-			expect(output).toContain("Next compaction:  ~0 / 30 tokens (0%)");
+			expect(output).toContain("Next compaction:  ~0 / 30 estimated source tokens (0%)");
 		});
 
 		it("falls back to calibrated threshold when contextWindow is zero in ratio mode", async () => {
@@ -231,7 +277,7 @@ describe("V3 /om:status", () => {
 				model: { contextWindow: 0 },
 			}).run();
 
-			expect(output).toContain("Next compaction:  ~0 / 30 tokens (0%)");
+			expect(output).toContain("Next compaction:  ~0 / 30 estimated source tokens (0%)");
 		});
 	});
 });


### PR DESCRIPTION
## Problem
PR #40 changed automatic compaction to compare full `ctx.getContextUsage().tokens` with `compactAfterTokens`. `/om:status` still showed raw tokens since the last compaction, so compaction could trigger while status showed progress below the threshold. The same path could call Pi compaction when no removable history existed.

## Solution
Measure compaction progress as provider context growth since the latest successful compaction:

```text
current provider context - post-compaction baseline
```

Use estimated source-token progress when provider usage is missing, unknown, lower than the baseline, or incomparable after a model/provider change. The initial and deferred trigger checks use the same resolver. `/om:status` uses the same progress and context-window precedence.

## Scope
- Updated status labels, README, and configuration/how-it-works documentation.
- Kept memory pool, worker chunk, stored memory, observation, reflection, and worker output token budgets unchanged.
- Added regression tests for the reported current-context versus post-compaction-growth mismatch, equality, first compaction, fallback cases, deferred checks, model changes, ratio mode, and status alignment.

## Validation
- `npm test`: 25 test files passed, 240 tests passed
- `npm run typecheck`: passed
- `git diff --check`: passed

## Follow-up
This PR does not suppress repeated `Nothing to compact (session too small)` failures. Pi owns compactability preflight, so retry suppression remains a separate follow-up.
