### PR TITLE
fix: restore raw compaction progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,8 +230,9 @@ Most users can start with the defaults and tune only if they have a specific rea
 ### Scaling compaction to the model's context window
 
 By default `compactAfterTokensMode` is `"calibrated"`, so the proactive
-compaction trigger uses the fixed `compactAfterTokens` growth threshold (81,000
-by default). This works well for typical ~128K–200K context models.
+compaction trigger uses the fixed `compactAfterTokens` estimated source-entry
+threshold (81,000 by default). This preserves the pre-PR #40 compaction metric
+for typical ~128K–200K context models.
 
 On a large-context model (e.g. 1M tokens) the calibrated default preempts
 compaction at ~81K, wasting most of the window. Switch to `"ratio"` mode to let
@@ -250,10 +251,10 @@ the trigger scale with the active model's `contextWindow`:
 In ratio mode the effective threshold is
 `floor(model.contextWindow * compactAfterTokensRatio)` (clamped to a minimum of
 1). With the example above, a 1,000,000-token window compacts after about
-500,000 tokens of provider context growth since the latest successful
-compaction; a 200,000-token window uses about 100,000. Retained summaries and
-kept messages are not counted again. If Pi cannot provide a comparable count,
-the extension uses estimated source-token progress.
+500,000 estimated source-entry tokens after the latest compaction boundary; a
+200,000-token window uses about 100,000. The threshold counts source entries,
+not Pi's system prompt, tool schemas, or provider accounting. Pi's native
+window-pressure compaction remains independent.
 
 `compactAfterTokensRatio` is user-tunable precisely because **context window ≠
 attention**. Some models advertise a large window but degrade at long range; set
@@ -273,8 +274,8 @@ on the `Next compaction` line regardless of mode.
 | `observeAfterTokens`        | `10000`       | Raw/source token threshold for observation runs.                                                  |
 | `observerChunkMaxTokens`    | derived       | Max estimated tokens serialized into one observer chunk (minimum `256`). Unset: `floor(contextWindow * 0.2)` of the resolved memory model, or `60000` when the window is unknown. Larger backlogs drain oldest-first; a single over-budget source is sent as a marked head/tail excerpt while the original source remains in the session ledger. |
 | `reflectAfterTokens`        | `20000`       | Raw/source token threshold for reflection runs; successful reflection creates dropper opportunities. |
-| `compactAfterTokens`        | `81000`       | Provider context-growth threshold for proactive auto-compaction (used directly in `"calibrated"` mode, and as the fallback in `"ratio"` mode). The raw source-token estimate is used when provider usage is unavailable or incomparable. |
-| `compactAfterTokensMode`    | `"calibrated"`| `"calibrated"` uses `compactAfterTokens` directly. The threshold measures provider context growth, with estimated source progress as a fallback. `"ratio"` scales the threshold by the active model's `contextWindow`. |
+| `compactAfterTokens`        | `81000`       | Estimated source-entry threshold for proactive auto-compaction, counted after the latest compaction boundary. |
+| `compactAfterTokensMode`    | `"calibrated"`| `"calibrated"` uses `compactAfterTokens` directly. `"ratio"` scales the source-entry threshold by the active model's `contextWindow`. |
 | `compactAfterTokensRatio`   | `0.68`        | In `"ratio"` mode, the threshold is `floor(contextWindow * ratio)`. Tunable because large windows do not always mean strong long-range attention. Must be in `(0, 1)`. |
 | `observationsPoolMaxTokens` | `20000`       | Observation-token budget used for compaction full-fold pressure.                                  |
 | `observationsPoolTargetTokens` | half of max | Active observation target used by post-reflection dropper maintenance.                            |
@@ -348,13 +349,11 @@ The high-level lifecycle:
 
 The important part: compaction does not need to rethink the whole session from scratch.
 
-The proactive compaction threshold measures provider context growth after the
-latest successful compaction. The first valid assistant usage after compaction
-sets the baseline. If Pi reports unknown usage, or a model/provider change makes
-the baseline incomparable, the extension falls back to estimated source-token
-progress. After a model/provider change, that fallback remains until a later
-successful compaction creates a new provider baseline. `/om:status` labels which
-metric it uses. Pi's own window-pressure compaction remains independent.
+The proactive compaction threshold counts estimated source-entry tokens after
+the latest compaction boundary. It includes source entries retained by
+`firstKeptEntryId` and newer source entries, while memory ledger entries and
+compaction metadata contribute zero. `/om:status` uses the same metric. Pi's
+own window-pressure compaction remains independent.
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -57,7 +57,7 @@ You can omit everything. Defaults work for ordinary sessions, and if `model` is 
 | `observeAfterTokens` | positive integer | `10000` | Raw/source token threshold for observer runs. |
 | `reflectAfterTokens` | positive integer | `20000` | Raw/source token threshold for reflector runs; successful reflection creates dropper maintenance opportunities. |
 | `observerChunkMaxTokens` | positive integer | derived; minimum `256` | Maximum estimated tokens sent to one observer run. Unset: 20% of the resolved memory model's context window, or `60000` when unknown. |
-| `compactAfterTokens` | positive integer | `81000` | Provider context-growth threshold for proactive auto-compaction. The raw source-token estimate is the fallback when provider usage is unavailable or incomparable. |
+| `compactAfterTokens` | positive integer | `81000` | Estimated source-entry threshold for proactive auto-compaction, counted after the latest compaction boundary. |
 | `observationsPoolMaxTokens` | positive integer | `20000` | Normal compaction-projection observation-token pressure that makes compaction do a full fold. |
 | `observationsPoolTargetTokens` | positive integer below max | half of `observationsPoolMaxTokens` | Folded active observation target used by post-reflection dropper maintenance. |
 | `agentMaxTurns` | positive integer | `16` | Shared nested-agent turn cap for observer, reflector, and dropper. |
@@ -103,7 +103,7 @@ Lower values distill reflections more often and therefore create more opportunit
 
 Default: `81000`.
 
-The auto-compaction trigger runs from Pi's `agent_end` hook. It counts provider context growth after the latest successful compaction. The first valid assistant usage after compaction sets the baseline. If Pi reports unknown usage, or a model/provider change makes the baseline incomparable, the extension uses estimated source-token progress after the compaction boundary. After a model/provider change, that fallback remains until a later successful compaction creates a new provider baseline. If the count reaches `compactAfterTokens`, the extension defers with `setTimeout(0)`, checks that Pi is idle, re-checks the same metric, and calls `ctx.compact()`.
+The auto-compaction trigger runs from Pi's `agent_end` hook. It counts estimated source-entry tokens after the latest compaction boundary. The count starts at `firstKeptEntryId` when Pi provides that boundary, so retained source entries remain part of the metric. Memory ledger entries and compaction metadata contribute zero. If the count reaches `compactAfterTokens`, the extension defers with `setTimeout(0)`, checks that Pi is idle, re-checks the same metric, and calls `ctx.compact()`. Pi's provider context usage is not used for this threshold.
 
 This trigger does not wait for observer, reflector, or dropper work. Actual compaction summary creation happens later in `session_before_compact`, where V3 compaction is deterministic and model-free.
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -204,12 +204,14 @@ It skips when:
 - `passive` is true;
 - compaction is already in flight;
 - the agent end event is a retryable error;
-- provider context growth since the latest successful compaction is below `compactAfterTokens`;
-- the provider baseline is unavailable or incomparable and estimated source progress is below `compactAfterTokens`;
+- estimated source-entry progress after the latest compaction boundary is below `compactAfterTokens`;
 - Pi is not idle after the deferred check;
-- the threshold is no longer met after the deferred check.
+- the raw threshold is no longer met after the deferred check.
 
-The provider baseline uses the first valid assistant usage after compaction. A model/provider change after that baseline causes fallback to estimated source progress until a later successful compaction creates a new provider baseline. When all checks pass, it calls `ctx.compact()`.
+The count starts at `firstKeptEntryId` when Pi provides that boundary. Memory
+ledger entries and compaction metadata contribute zero. The trigger uses this
+same raw metric before scheduling and in the deferred re-check, then calls
+`ctx.compact()` when all checks pass.
 
 This trigger does not wait for observer, reflector, or dropper promises. That is intentional: background memory work should never make compaction feel stuck.
 

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -6,7 +6,7 @@ import {
 	diffProjection,
 	foldLedger,
 	fullProjection,
-	compactionProgress,
+	rawTokensSinceLastCompaction,
 	rawTokensSinceObservationCoverage,
 	rawTokensSinceReflectionCoverage,
 	visibleProjection,
@@ -61,13 +61,9 @@ export function registerStatusCommand(pi: ExtensionAPI, runtime: Runtime): void 
 			);
 			const obsProgress = rawTokensSinceObservationCoverage(entries);
 			const reflectionProgress = rawTokensSinceReflectionCoverage(entries);
-			const contextUsage = typeof ctx.getContextUsage === "function" ? ctx.getContextUsage() : undefined;
-			const compaction = compactionProgress(entries, contextUsage?.tokens);
-			const contextWindow =
-				contextUsage?.contextWindow
-				?? (typeof ctx.model?.contextWindow === "number" ? ctx.model.contextWindow : undefined);
+			const compactionProgress = rawTokensSinceLastCompaction(entries);
+			const contextWindow = typeof ctx.model?.contextWindow === "number" ? ctx.model.contextWindow : undefined;
 			const compactThreshold = resolveCompactAfterTokens(runtime.config, contextWindow);
-			const compactionMetricLabel = compaction.source === "provider" ? "provider context growth" : "estimated source";
 
 			const passiveLines = runtime.config.passive === true
 				? [
@@ -86,7 +82,7 @@ export function registerStatusCommand(pi: ExtensionAPI, runtime: Runtime): void 
 				"── Activity ──",
 				`Next observation: ~${obsProgress.toLocaleString()} / ${runtime.config.observeAfterTokens.toLocaleString()} tokens (${pct(obsProgress, runtime.config.observeAfterTokens)}%)`,
 				`Next reflection:  ~${reflectionProgress.toLocaleString()} / ${runtime.config.reflectAfterTokens.toLocaleString()} tokens (${pct(reflectionProgress, runtime.config.reflectAfterTokens)}%)`,
-				`Next compaction:  ~${compaction.tokens.toLocaleString()} / ${compactThreshold.toLocaleString()} ${compactionMetricLabel} tokens (${pct(compaction.tokens, compactThreshold)}%)`,
+				`Next compaction:  ~${compactionProgress.toLocaleString()} / ${compactThreshold.toLocaleString()} estimated source tokens (${pct(compactionProgress, compactThreshold)}%)`,
 				`Visible observation pool: ~${visibleObservationTokens.toLocaleString()} / ${runtime.config.observationsPoolMaxTokens.toLocaleString()} tokens (${pct(visibleObservationTokens, runtime.config.observationsPoolMaxTokens)}%)`,
 				`Active observation pool: ~${activeObservationPool.observationTokens.toLocaleString()} / ${runtime.config.observationsPoolTargetTokens.toLocaleString()} target tokens (${pct(activeObservationPool.observationTokens, runtime.config.observationsPoolTargetTokens)}%)`,
 				`Reflection pool:         ~${visibleReflectionTokens.toLocaleString()} tokens`,

--- a/src/hooks/compaction-trigger.ts
+++ b/src/hooks/compaction-trigger.ts
@@ -1,6 +1,6 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { resolveCompactAfterTokens } from "../config.js";
-import { compactionProgress, type Entry } from "../session-ledger/index.js";
+import { rawTokensSinceLastCompaction, type Entry } from "../session-ledger/index.js";
 import type { Runtime } from "../runtime.js";
 
 /**
@@ -34,22 +34,18 @@ export function registerCompactionTrigger(pi: ExtensionAPI, runtime: Runtime): v
 
 		const entries = ctx.sessionManager?.getBranch?.() as Entry[] | undefined;
 		if (!entries) return;
-		const contextUsage = typeof ctx.getContextUsage === "function" ? ctx.getContextUsage() : undefined;
-		const progress = compactionProgress(entries, contextUsage?.tokens);
-		const contextWindow =
-			contextUsage?.contextWindow
-			?? (typeof ctx.model?.contextWindow === "number" ? ctx.model.contextWindow : undefined);
+		const progress = rawTokensSinceLastCompaction(entries);
+		const contextWindow = typeof ctx.model?.contextWindow === "number" ? ctx.model.contextWindow : undefined;
 		const threshold = resolveCompactAfterTokens(runtime.config, contextWindow);
-		if (progress.tokens < threshold) return;
+		if (progress < threshold) return;
 
 		// Capture ctx properties synchronously — the setTimeout + async work below
 		// may outlive the extension ctx (stale after session replacement/reload).
 		const hasUI = ctx.hasUI;
 		const ui = ctx.ui;
 
-		const progressLabel = progress.source === "provider" ? "provider context growth" : "estimated source";
 		if (hasUI) ui?.notify(
-			`Observational memory: compaction threshold reached (~${progress.tokens.toLocaleString()} ${progressLabel} tokens); triggering compaction`,
+			`Observational memory: compaction threshold reached (~${progress.toLocaleString()} estimated source tokens); triggering compaction`,
 			"info",
 		);
 
@@ -69,9 +65,8 @@ export function registerCompactionTrigger(pi: ExtensionAPI, runtime: Runtime): v
 					runtime.compactInFlight = false;
 					return;
 				}
-				const currentUsage = typeof ctx.getContextUsage === "function" ? ctx.getContextUsage() : undefined;
-				const currentProgress = compactionProgress(currentEntries, currentUsage?.tokens);
-				if (currentProgress.tokens < threshold) {
+				const currentProgress = rawTokensSinceLastCompaction(currentEntries);
+				if (currentProgress < threshold) {
 					runtime.compactInFlight = false;
 					if (hasUI) ui?.notify(
 						"Observational memory: compaction skipped — another compaction already ran before deferred compaction",

--- a/src/session-ledger/progress.ts
+++ b/src/session-ledger/progress.ts
@@ -119,16 +119,9 @@ export function findLastCompactionIndex(entries: Entry[]): number {
 
 // ==== Real (provider-reported) token accounting ====
 //
-// The raw source-entry estimate (estimateEntryTokens) systematically undercounts
-// the live context: it omits the system prompt, tool schemas, thinking tokens,
-// and drifts from the provider's own tokenizer by ~20-46% in practice. Trigger
-// thresholds therefore compared an unknowable estimate against a configured
-// number, so "observe after 10000 tokens" fired at an unpredictable 11-19K real
-// tokens (and compaction could lag the visible footer percentage so far that it
-// never fired at all). These helpers measure real context growth from the
-// provider-reported usage attached to assistant/compaction entries — the same
-// basis the footer context percentage uses — so a configured threshold means
-// real tokens.
+// These helpers measure context growth from provider-reported usage for the
+// observation and reflection coverage clocks. Automatic compaction keeps its
+// separate raw source-entry clock because its setting counts ledger entries.
 
 type UsageLike = {
 	totalTokens?: number;
@@ -174,18 +167,6 @@ export function realContextTokensAfterCompaction(entries: Entry[], compactionIdx
 		if (t !== undefined) return t;
 	}
 	return undefined;
-}
-
-function hasModelChangeAfterCompactionBaseline(entries: Entry[], compactionIdx: number): boolean {
-	let baselineFound = false;
-	for (let i = compactionIdx + 1; i < entries.length; i++) {
-		if (!baselineFound && validAssistantContextTokens(entries[i]) !== undefined) {
-			baselineFound = true;
-			continue;
-		}
-		if (baselineFound && entries[i].type === "model_change") return true;
-	}
-	return false;
 }
 
 /**
@@ -245,30 +226,4 @@ export function rawTokensSinceLastCompaction(entries: Entry[]): number {
 
 	if (firstKeptIndex === -1) return rawTokensAfterIndex(entries, compactionIndex);
 	return rawTokensAfterIndex(entries, firstKeptIndex - 1);
-}
-
-export type CompactionProgress = {
-	tokens: number;
-	source: "provider" | "raw";
-};
-
-/**
- * Returns context growth since the latest successful compaction when Pi's
- * provider usage is comparable. Raw source-token progress is the safe fallback.
- */
-export function compactionProgress(entries: Entry[], currentContextTokens: number | null | undefined): CompactionProgress {
-	const raw = rawTokensSinceLastCompaction(entries);
-	if (typeof currentContextTokens !== "number" || !Number.isFinite(currentContextTokens)) {
-		return { tokens: raw, source: "raw" };
-	}
-
-	const compactionIdx = findLastCompactionIndex(entries);
-	if (compactionIdx >= 0 && hasModelChangeAfterCompactionBaseline(entries, compactionIdx)) {
-		return { tokens: raw, source: "raw" };
-	}
-
-	const real = realTokensSinceAnchor(entries, undefined, currentContextTokens);
-	return real === undefined
-		? { tokens: raw, source: "raw" }
-		: { tokens: real, source: "provider" };
 }

--- a/tests/compaction-trigger.test.ts
+++ b/tests/compaction-trigger.test.ts
@@ -184,14 +184,19 @@ describe("V3 compaction trigger", () => {
 		expect(ctx.compact).toHaveBeenCalledTimes(1);
 	});
 
-	it("does not compact when full context exceeds the threshold but anchored growth does not", async () => {
+	it("does not compact when provider context and anchored growth exceed the threshold but raw progress does not", async () => {
 		const { handler, runtime } = captureHandler({ compactAfterTokens: 130000 });
 		const branch = [
-			compactionEntry("cmp-1"),
-			rawMessage("assistant-1", "done", {
-				message: { role: "assistant", content: "done", stopReason: "end_turn", usage: { totalTokens: 60072 } },
+			compactionEntry("cmp-1", { firstKeptEntryId: "baseline" }),
+			rawMessage("baseline", "baseline", {
+				message: {
+					role: "assistant",
+					content: "baseline",
+					stopReason: "end_turn",
+					usage: { totalTokens: 5000 },
+				},
 			}),
-			textCustomMessage("raw-1", "small"),
+			textCustomMessage("raw-1", "a".repeat(302_248)), // 75,562 tokens plus the 2-token baseline message
 		];
 		const ctx = fakeCtx([branch], {
 			getContextUsage: vi.fn(() => ({ tokens: 135636, contextWindow: 200000 })),
@@ -204,10 +209,17 @@ describe("V3 compaction trigger", () => {
 		expect(runtime.compactInFlight).toBe(false);
 	});
 
-	it("uses provider context from zero before the first compaction", async () => {
-		const { handler } = captureHandler({ compactAfterTokens: 130000 });
-		const ctx = fakeCtx([dueBranch], {
-			getContextUsage: vi.fn(() => ({ tokens: 130000, contextWindow: 200000 })),
+	it("uses raw progress when provider growth is lower than the raw threshold", async () => {
+		const { handler } = captureHandler({ compactAfterTokens: 3 });
+		const branch = [
+			compactionEntry("cmp-1", { firstKeptEntryId: "raw-1" }),
+			rawMessage("assistant-1", "done", {
+				message: { role: "assistant", content: "done", stopReason: "end_turn", usage: { totalTokens: 100 } },
+			}),
+			textCustomMessage("raw-1", "aaaaaaaaaaaa"),
+		];
+		const ctx = fakeCtx([branch], {
+			getContextUsage: vi.fn(() => ({ tokens: 101, contextWindow: 200000 })),
 		});
 
 		handler(agentEnd(), ctx);
@@ -216,16 +228,72 @@ describe("V3 compaction trigger", () => {
 		expect(ctx.compact).toHaveBeenCalledTimes(1);
 	});
 
-	it("compacts when anchored provider growth equals the threshold", async () => {
-		const { handler } = captureHandler({ compactAfterTokens: 130000 });
+	it("uses raw progress from the first kept entry through the current branch", async () => {
+		const { handler } = captureHandler({ compactAfterTokens: 3 });
 		const branch = [
-			compactionEntry("cmp-1"),
-			rawMessage("assistant-1", "done", {
-				message: { role: "assistant", content: "done", stopReason: "end_turn", usage: { totalTokens: 60000 } },
-			}),
+			textCustomMessage("old", "bbbbbbbbbbbb"),
+			compactionEntry("cmp-1", { firstKeptEntryId: "kept" }),
+			textCustomMessage("kept", "aaaaaaaa"),
+			textCustomMessage("new", "bbbbbbbbbbbb"),
 		];
 		const ctx = fakeCtx([branch], {
-			getContextUsage: vi.fn(() => ({ tokens: 190000, contextWindow: 200000 })),
+			getContextUsage: vi.fn(() => ({ tokens: 1, contextWindow: 200000 })),
+		});
+
+		handler(agentEnd(), ctx);
+		await vi.runAllTimersAsync();
+
+		expect(ctx.compact).toHaveBeenCalledTimes(1);
+	});
+
+	it("uses raw progress from the branch start before the first compaction", async () => {
+		const { handler } = captureHandler({ compactAfterTokens: 3 });
+		const ctx = fakeCtx([dueBranch], {
+			getContextUsage: vi.fn(() => ({ tokens: 1, contextWindow: 200000 })),
+		});
+
+		handler(agentEnd(), ctx);
+		await vi.runAllTimersAsync();
+
+		expect(ctx.compact).toHaveBeenCalledTimes(1);
+	});
+
+	it("uses the same raw metric after deferred re-check", async () => {
+		const { handler, runtime } = captureHandler({ compactAfterTokens: 3 });
+		const ctx = fakeCtx([dueBranch, dueBranch], {
+			getContextUsage: vi.fn(() => ({ tokens: 1, contextWindow: 200000 })),
+		});
+
+		handler(agentEnd(), ctx);
+		await vi.runAllTimersAsync();
+
+		expect(ctx.compact).toHaveBeenCalledTimes(1);
+		expect(runtime.compactInFlight).toBe(true);
+	});
+
+	it("ignores high provider context before the first compaction", async () => {
+		const { handler } = captureHandler({ compactAfterTokens: 130000 });
+		const ctx = fakeCtx([dueBranch], {
+			getContextUsage: vi.fn(() => ({ tokens: 130000, contextWindow: 200000 })),
+		});
+
+		handler(agentEnd(), ctx);
+		await vi.runAllTimersAsync();
+
+		expect(ctx.compact).not.toHaveBeenCalled();
+	});
+
+	it("compacts when raw progress equals the threshold", async () => {
+		const { handler } = captureHandler({ compactAfterTokens: 3 });
+		const branch = [
+			compactionEntry("cmp-1", { firstKeptEntryId: "raw-1" }),
+			rawMessage("assistant-1", "done", {
+				message: { role: "assistant", content: "done", stopReason: "end_turn", usage: { totalTokens: 100 } },
+			}),
+			textCustomMessage("raw-1", "aaaaaaaaaaaa"),
+		];
+		const ctx = fakeCtx([branch], {
+			getContextUsage: vi.fn(() => ({ tokens: 101, contextWindow: 200000 })),
 		});
 
 		handler(agentEnd(), ctx);
@@ -247,18 +315,10 @@ describe("V3 compaction trigger", () => {
 		expect(ctx.compact).not.toHaveBeenCalled();
 	});
 
-	it("rechecks anchored growth after deferral", async () => {
-		const { handler, runtime } = captureHandler({ compactAfterTokens: 130000 });
-		const branch = [
-			compactionEntry("cmp-1"),
-			rawMessage("assistant-1", "done", {
-				message: { role: "assistant", content: "done", stopReason: "end_turn", usage: { totalTokens: 60000 } },
-			}),
-		];
-		const ctx = fakeCtx([branch], {
-			getContextUsage: vi.fn()
-				.mockReturnValueOnce({ tokens: 190000, contextWindow: 200000 })
-				.mockReturnValueOnce({ tokens: 120000, contextWindow: 200000 }),
+	it("rechecks raw progress after deferral", async () => {
+		const { handler, runtime } = captureHandler({ compactAfterTokens: 3 });
+		const ctx = fakeCtx([dueBranch, belowBranch], {
+			getContextUsage: vi.fn(() => ({ tokens: 1, contextWindow: 200000 })),
 		});
 
 		handler(agentEnd(), ctx);
@@ -319,7 +379,7 @@ describe("V3 compaction trigger", () => {
 			expect(ctx.compact).not.toHaveBeenCalled();
 		});
 
-		it("prefers the provider context window in ratio mode", async () => {
+		it("uses the model context window in ratio mode", async () => {
 			const { handler } = captureHandler({
 				compactAfterTokens: 81000,
 				compactAfterTokensMode: "ratio",
@@ -333,7 +393,7 @@ describe("V3 compaction trigger", () => {
 			handler(agentEnd(), ctx);
 			await vi.runAllTimersAsync();
 
-			expect(ctx.compact).not.toHaveBeenCalled();
+			expect(ctx.compact).toHaveBeenCalledTimes(1);
 		});
 
 		it("falls back to calibrated value when model.contextWindow is unavailable", async () => {

--- a/tests/session-ledger-progress.test.ts
+++ b/tests/session-ledger-progress.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 
 import {
-	compactionProgress,
 	earlierCoverageMarkerId,
 	entryIndexById,
 	isSourceEntry,
@@ -19,7 +18,6 @@ import {
 	V3_REFLECTIONS_RECORDED,
 	branchSummary,
 	compactionEntry,
-	rawMessage,
 	observation,
 	observationsDroppedEntry,
 	observationsRecordedEntry,
@@ -141,38 +139,5 @@ describe("session-ledger V3 progress helpers", () => {
 		];
 
 		expect(rawTokensSinceLastCompaction(entries)).toBe(3); // raw-1 + raw-2 from live tail starting at firstKeptEntryId
-	});
-
-	it("uses provider context growth after compaction", () => {
-		const entries = [
-			compactionEntry("cmp-1"),
-			rawMessage("assistant-1", "done", {
-				message: { role: "assistant", content: "done", stopReason: "end_turn", usage: { totalTokens: 60072 } },
-			}),
-		];
-
-		expect(compactionProgress(entries, 135636)).toEqual({ tokens: 75564, source: "provider" });
-	});
-
-	it("falls back to raw progress when provider usage has no post-compaction baseline", () => {
-		const entries = [
-			compactionEntry("cmp-1"),
-			textCustomMessage("raw-1", "aaaaaaaa"),
-		];
-
-		expect(compactionProgress(entries, 135636)).toEqual({ tokens: 2, source: "raw" });
-	});
-
-	it("falls back to raw progress after a model change", () => {
-		const entries = [
-			compactionEntry("cmp-1"),
-			rawMessage("assistant-1", "done", {
-				message: { role: "assistant", content: "done", stopReason: "end_turn", usage: { totalTokens: 60072 } },
-			}),
-			{ type: "model_change", id: "model-1", timestamp: "2026-05-02T10:00:00.000Z" },
-			textCustomMessage("raw-1", "aaaaaaaa"),
-		];
-
-		expect(compactionProgress(entries, 135636)).toEqual({ tokens: 2, source: "raw" });
 	});
 });

--- a/tests/status-command.test.ts
+++ b/tests/status-command.test.ts
@@ -131,12 +131,13 @@ describe("V3 /om:status", () => {
 		expect(output).not.toContain("visible observation tokens");
 	});
 
-	it("shows provider context growth since compaction", async () => {
+	it("shows raw source progress and ignores provider context", async () => {
 		const entries = [
-			compactionEntry("cmp-1"),
+			compactionEntry("cmp-1", { firstKeptEntryId: "raw-1" }),
 			rawMessage("assistant-1", "done", {
 				message: { role: "assistant", content: "done", stopReason: "end_turn", usage: { totalTokens: 60072 } },
 			}),
+			textCustomMessage("raw-1", "aaaaaaaaaaaa"),
 		];
 
 		const output = await setup({
@@ -144,7 +145,7 @@ describe("V3 /om:status", () => {
 			contextUsage: { tokens: 135636, contextWindow: 200000 },
 		}).run();
 
-		expect(output).toContain("Next compaction:  ~75,564 / 30 provider context growth tokens");
+		expect(output).toContain("Next compaction:  ~3 / 30 estimated source tokens");
 	});
 
 	it("shows over-target active observation pool in the Activity section", async () => {
@@ -216,7 +217,7 @@ describe("V3 /om:status", () => {
 			expect(output).toContain("Next compaction:  ~0 / 500,000 estimated source tokens (0%)");
 		});
 
-		it("prefers provider contextWindow over model contextWindow in ratio mode", async () => {
+		it("uses model contextWindow in ratio mode", async () => {
 			const output = await setup({
 				entries: [],
 				runtime: {
@@ -235,7 +236,7 @@ describe("V3 /om:status", () => {
 				contextUsage: { tokens: null, contextWindow: 200_000 },
 			}).run();
 
-			expect(output).toContain("Next compaction:  ~0 / 100,000 estimated source tokens (0%)");
+			expect(output).toContain("Next compaction:  ~0 / 50,000 estimated source tokens (0%)");
 		});
 
 		it("falls back to calibrated threshold when model is unavailable in ratio mode", async () => {


### PR DESCRIPTION
## Summary

PR #40 changed automatic compaction from estimated raw source progress to total provider context. PR #45 then changed it to anchored provider growth. This PR restores the original `rawTokensSinceLastCompaction()` contract.

The restored metric applies to:

- The initial automatic-compaction check.
- The deferred recheck.
- `/om:status`.

Observation and reflection scheduling retain their provider-based accounting. Ratio mode again uses the active model context window, matching the pre-PR #40 behavior.

No configuration keys, defaults, session data, or migrations change.

## Regression proof

The decisive case separates the three metrics:

- Current provider context: `135,636`
- Provider growth: `130,636`
- Raw source progress: `75,564`
- Threshold: `130,000`

The restored behavior does not trigger extension compaction because raw source progress remains below the threshold. The regression fails under both PR #40 and PR #45 behavior.

## Validation

- `npm test`: 25 test files passed, 241 tests passed
- `npm run typecheck`: passed
- `git diff --check`: passed

## Tradeoffs and follow-up

Raw source progress excludes system prompts, tool schemas, and other provider-specific context accounting. Pi-native compaction remains the total-context safety mechanism.

Repeated `Nothing to compact (session too small)` suppression is not included in this change.
