### PR TITLE
feat: thread cwd into observer/reflector agents for project-scope awareness

### DIFF
--- a/src/agents/observer/agent.ts
+++ b/src/agents/observer/agent.ts
@@ -23,6 +23,7 @@ interface RunObserverArgs {
 	agentLoop?: typeof agentLoop;
 	maxTurns?: number;
 	thinkingLevel?: ModelThinkingLevel;
+	cwd?: string;
 }
 
 const RelevanceSchema = Type.Union([
@@ -99,7 +100,7 @@ export function normalizeSourceEntryIds(
 }
 
 export async function runObserver(args: RunObserverArgs): Promise<Observation[] | undefined> {
-	const { model, apiKey, headers, priorReflections, priorObservations, chunk, allowedSourceEntryIds, signal } = args;
+	const { model, apiKey, headers, priorReflections, priorObservations, chunk, allowedSourceEntryIds, signal, cwd } = args;
 	const conversation = chunk.trim();
 	if (!conversation) return undefined;
 
@@ -158,7 +159,8 @@ export async function runObserver(args: RunObserverArgs): Promise<Observation[] 
 	};
 
 	const now = nowTimestamp();
-	const userText = `Current local time: ${now}
+	const cwdLine = cwd ? `\nWorking directory: ${cwd}` : "";
+	const userText = `Current local time: ${now}${cwdLine}
 
 CURRENT REFLECTIONS:
 ${joinOrEmpty(priorReflections)}

--- a/src/agents/observer/prompts.ts
+++ b/src/agents/observer/prompts.ts
@@ -9,6 +9,7 @@ You receive:
 - Current observations (already-recorded observations, each shown as "[id] YYYY-MM-DD HH:MM [relevance] content").
 - A new chunk of conversation with source entry labels and inline message timestamps. Each source block starts with "[Source entry id: <id>]" followed by content formatted as "[User @ YYYY-MM-DD HH:MM]:", "[Assistant @ ...]:", "[Tool result for <name> @ ...]:", custom messages, or branch summaries.
 - A current local time fallback for observations that have no obvious message timestamp.
+- The current working directory, when available — the project this session belongs to. Use it to judge whether content is in-scope for this project.
 
 How you work:
 1. Read reflections and current observations so you know what is already captured.
@@ -16,6 +17,12 @@ How you work:
 3. Call record_observations with a batch covering part (or all) of the chunk.
 4. Read the progress receipt. If content remains uncovered, call again. You may call the tool many times.
 5. When the chunk is fully covered, STOP calling the tool and reply with a brief plain-text confirmation (one short sentence). That ends the run.
+
+Project scope:
+- The current working directory is the project this session belongs to. Observations should serve future turns in THIS project.
+- Conversation sometimes references other projects, external documents, or unrelated codebases (e.g. the agent reads a file from a different project directory, or the user pastes notes from elsewhere). Treat content that is clearly about a DIFFERENT project as low relevance or skip it entirely, unless the user explicitly states it applies to the current project too.
+- Cross-project technical trivia (how a library works in another codebase, debugging notes from a different project) is NOT durable orientation for the current project. Do not record it as if it were a current-project fact.
+- When unsure whether content belongs to the current project, prefer lower relevance over higher.
 
 What to emit:
 - Produce NEW observations for the new chunk only. Do not restate facts already present in reflections or current observations unless something has materially changed.

--- a/src/agents/reflector/agent.ts
+++ b/src/agents/reflector/agent.ts
@@ -29,6 +29,7 @@ interface RunReflectorArgs {
 	agentLoop?: typeof agentLoop;
 	maxTurns?: number;
 	thinkingLevel?: ModelThinkingLevel;
+	cwd?: string;
 }
 
 const RecordReflectionsSchema = Type.Object({
@@ -105,7 +106,7 @@ function normalizeReflectionContent(content: string): string | undefined {
 }
 
 export async function runReflector(args: RunReflectorArgs): Promise<Reflection[] | undefined> {
-	const { model, apiKey, headers, reflections, observations, signal } = args;
+	const { model, apiKey, headers, reflections, observations, signal, cwd } = args;
 	if (observations.length === 0) return undefined;
 
 	const coverageById = reflectionCoverageMap(observations, reflections);
@@ -165,7 +166,8 @@ export async function runReflector(args: RunReflectorArgs): Promise<Reflection[]
 		},
 	};
 
-	const userText = `CURRENT REFLECTIONS:\n${joinOrEmpty(reflections.map(reflectionToSummaryLine))}\n\nCURRENT OBSERVATIONS:\n${joinOrEmpty(observations.map((observation) => observationToReflectorLine(observation, coverageTierForObservation(observation, coverageById))))}\n\nCrystallize any missing durable facts or patterns into new reflections. If nothing is stable enough, do not call the tool.`;
+	const cwdLine = cwd ? `Working directory: ${cwd}\n\n` : "";
+	const userText = `${cwdLine}CURRENT REFLECTIONS:\n${joinOrEmpty(reflections.map(reflectionToSummaryLine))}\n\nCURRENT OBSERVATIONS:\n${joinOrEmpty(observations.map((observation) => observationToReflectorLine(observation, coverageTierForObservation(observation, coverageById))))}\n\nCrystallize any missing durable facts or patterns into new reflections. If nothing is stable enough, do not call the tool.`;
 	const prompts: Message[] = [{ role: "user", content: [{ type: "text", text: userText }], timestamp: Date.now() }];
 	const context: AgentContext = { systemPrompt: REFLECTOR_SYSTEM, messages: [], tools: [recordReflections as AgentTool<any>] };
 	const reasoning = (model as { reasoning?: unknown }).reasoning;

--- a/src/agents/reflector/prompts.ts
+++ b/src/agents/reflector/prompts.ts
@@ -8,6 +8,13 @@ You receive:
 - Current reflections: durable facts already crystallized.
 - Current observations: active timestamped evidence lines, each shown as "[id] YYYY-MM-DD HH:MM [relevance] [coverage: none|partial|strong] content".
 - Coverage tiers are review context: none means no current reflection supports the observation id, partial means exactly one current reflection supports it, and strong means two or more current reflections support it. Coverage is not a quota, target, priority score, or instruction to emit reflections.
+- The current working directory, when available — the project this session belongs to. Use it to judge whether observations are in-scope before crystallizing them.
+
+Project scope:
+- The current working directory is the project this session belongs to. Reflections should orient future turns in THIS project.
+- Observations sometimes reference other projects, external documents, or unrelated codebases (e.g. notes from a different project directory that were read into this session). Do NOT crystallize cross-project technical trivia into reflections for the current project. A durable fact about how a library behaves in another codebase is not a current-project invariant.
+- Only crystallize cross-project content when the user explicitly states it applies to the current project, or it is a general tooling/environment fact that is project-agnostic (e.g. a CLI flag, a global preference).
+- When unsure whether an observation belongs to the current project, leave it as an observation rather than promoting it to a reflection.
 
 What to emit:
 - Emit only new durable reflections not already present in current reflections.

--- a/src/hooks/consolidation-trigger.ts
+++ b/src/hooks/consolidation-trigger.ts
@@ -317,6 +317,7 @@ async function runObserverStage(
 			allowedSourceEntryIds: sourceEntryIds,
 			maxTurns: runtime.config.agentMaxTurns,
 			thinkingLevel: runtime.config.model?.thinking ?? "low",
+			cwd: ctx.cwd,
 		});
 	} catch (error) {
 		if (error instanceof ObserverStreamError) {
@@ -387,6 +388,7 @@ async function runReflectorStage(
 		observations: folded.activeObservations,
 		maxTurns: runtime.config.agentMaxTurns,
 		thinkingLevel: runtime.config.model?.thinking ?? "low",
+		cwd: ctx.cwd,
 	});
 	if (!reflections) return { outcome: "continue", sameRunReflections: [] };
 

--- a/tests/consolidation-trigger.test.ts
+++ b/tests/consolidation-trigger.test.ts
@@ -228,6 +228,24 @@ describe("V3 consolidation trigger", () => {
 		expect(pi.appendEntry).toHaveBeenCalledWith(OM_OBSERVATIONS_RECORDED, { observations: [obs], coversUpToId: "raw-1" });
 	});
 
+	it("forwards the session cwd to observer and reflector agents", async () => {
+		const newRef = reflection("ffffffffffff", ["aaaaaaaaaaaa"]);
+		mockAgents.runObserver.mockResolvedValueOnce([obsA]);
+		mockAgents.runReflector.mockResolvedValueOnce([newRef]);
+		const entries = [textCustomMessage("raw-1", "aaaaaaaa")];
+		const { fire, runLaunchedWork } = setup({ entries });
+
+		fire();
+		await runLaunchedWork();
+
+		expect(mockAgents.runObserver).toHaveBeenCalledWith(expect.objectContaining({
+			cwd: "/tmp/project",
+		}));
+		expect(mockAgents.runReflector).toHaveBeenCalledWith(expect.objectContaining({
+			cwd: "/tmp/project",
+		}));
+	});
+
 	it("forwards OAuth-shaped auth (headers, no apiKey) to the observer agent", async () => {
 		const obs = observation("cccccccccccc", { sourceEntryIds: ["raw-1"], tokenCount: 4 });
 		mockAgents.runObserver.mockResolvedValueOnce([obs]);

--- a/tests/observer.test.ts
+++ b/tests/observer.test.ts
@@ -168,6 +168,28 @@ describe("runObserver", () => {
 
 		expect(seenReasoning).toBeUndefined();
 	});
+
+	it("injects the working directory into the observer user text when provided", async () => {
+		let userText = "";
+		const loop = fakeAgentLoop((prompts) => {
+			userText = prompts[0].content[0].text;
+		});
+
+		await runObserver({ ...baseArgs, cwd: "/tmp/test-project", agentLoop: loop });
+
+		expect(userText).toContain("Working directory: /tmp/test-project");
+	});
+
+	it("omits the working directory line when cwd is not provided", async () => {
+		let userText = "";
+		const loop = fakeAgentLoop((prompts) => {
+			userText = prompts[0].content[0].text;
+		});
+
+		await runObserver({ ...baseArgs, agentLoop: loop });
+
+		expect(userText).not.toContain("Working directory:");
+	});
 });
 
 describe("normalizeSourceEntryIds", () => {

--- a/tests/reflector.test.ts
+++ b/tests/reflector.test.ts
@@ -208,4 +208,26 @@ describe("V3 reflector agent", () => {
 		const loop = fakeAgentLoop(() => {});
 		await expect(runReflector({ ...baseArgs, agentLoop: loop })).resolves.toBeUndefined();
 	});
+
+	it("injects the working directory into the reflector user text when provided", async () => {
+		let userText = "";
+		const loop = fakeAgentLoop((prompts) => {
+			userText = prompts[0].content[0].text;
+		});
+
+		await runReflector({ ...baseArgs, cwd: "/tmp/test-project", agentLoop: loop });
+
+		expect(userText).toContain("Working directory: /tmp/test-project");
+	});
+
+	it("omits the working directory line when cwd is not provided", async () => {
+		let userText = "";
+		const loop = fakeAgentLoop((prompts) => {
+			userText = prompts[0].content[0].text;
+		});
+
+		await runReflector({ ...baseArgs, agentLoop: loop });
+
+		expect(userText).not.toContain("Working directory:");
+	});
 });


### PR DESCRIPTION
# PR: Thread cwd into observer/reflector agents for project-scope awareness

## Problem

In a coding session for project A, the agent sometimes reads documentation, notes, or files that belong to a different project B (for example, referencing another codebase's debugging notes or a library writeup stored in a separate directory). Because the observer and reflector agents have no notion of the current working directory, they record these cross-project details as observations and crystallize them into reflections.

These reflections then propagate into compaction summaries and subsequent system prompts, so later turns in project A are oriented by durable "facts" about project B — facts the user never asked to remember for project A. Over multiple sessions this pollutes the reflection store with cross-project trivia that does not help (and sometimes misleads) future work in the current project.

## Root cause

The consolidation pipeline already has the session `cwd` available in `ConsolidationCtx`, but:

1. `runObserver` and `runReflector` do not receive `cwd` — neither `RunObserverArgs` nor `RunReflectorArgs` has a `cwd` field.
2. Neither agent's system prompt (`OBSERVER_SYSTEM`, `REFLECTOR_SYSTEM`) mentions the working directory or asks the agent to weigh project relevance before recording/crystallizing.
3. `consolidation-trigger.ts` calls `runObserver` and `runReflector` without forwarding `ctx.cwd`.

So the LLM has no way to know which project a piece of content belongs to, and no instruction to filter cross-project material.

## Changes

- **`RunObserverArgs` / `RunReflectorArgs`**: add optional `cwd?: string`.
- **`runObserver` / `runReflector`**: when `cwd` is provided, inject a `Working directory: <cwd>` line into the agent user text (observer: after the timestamp; reflector: before `CURRENT REFLECTIONS`). Omitted entirely when `cwd` is absent — fully backward compatible.
- **Observer & reflector system prompts**: add a `Project scope` section guiding the agents to:
  - treat content clearly about a *different* project as low relevance or skip it (observer) / not crystallize it (reflector),
  - only keep cross-project content when the user explicitly states it applies to the current project, or it is genuinely project-agnostic (e.g. a global CLI flag),
  - prefer lower relevance / leave-as-observation when project membership is unclear.
- **`consolidation-trigger.ts`**: pass `cwd: ctx.cwd` to both `runObserver` and `runReflector`.
- **Tests**:
  - `observer.test.ts`: cwd injected into user text when provided; omitted when absent.
  - `reflector.test.ts`: same coverage.
  - `consolidation-trigger.test.ts`: end-to-end — `ctx.cwd` is forwarded to both mocked agents.

## Design notes

- The `cwd` field is optional on both arg types, so existing callers (tests, any other callers) keep working without changes.
- The prompt guidance is additive — it does not change the existing durability/relevance criteria, only adds a project-scope lens on top.
- This is intentionally a light-touch fix: it gives the agents the information and the guidance, without hard-blocking cross-project content (the user may legitimately want a cross-project fact recorded if they say so).

## Verification

- `npm run typecheck` — passes.
- `npm test` — 245 tests pass (25 files), including 5 new tests.

## Related

- Issue #21 — confirms reflections are single-session scope by design; this PR addresses the intra-session cross-project content path.
