### PR TITLE
fix(runtime): don't reject providers that authenticate at request time (Bedrock SigV4, Vertex ADC)

### DIFF
--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1,4 +1,5 @@
 import { type Config, DEFAULTS, loadConfig } from "./config.js";
+import { debugLog } from "./debug-log.js";
 
 export type ResolveResult =
 	| { ok: true; model: unknown; apiKey?: string; headers?: Record<string, string> }
@@ -10,20 +11,65 @@ export type ResolveResult =
  * OAuth providers (kimi-coding, xai, openai-codex, anthropic OAuth, …) authenticate via
  * `toAuth()` returning `{ headers: { Authorization: "Bearer …" } }` with no apiKey, and
  * pi-ai providers accept a caller-supplied Authorization header in place of an apiKey.
+ *
+ * NOTE: a `false` result does NOT mean "unauthenticated" — see `resolveModel`. Providers
+ * that authenticate at request time (Amazon Bedrock SigV4 from AWS_PROFILE/SSO, Google
+ * Vertex ADC) legitimately expose neither an apiKey nor a header, because pi signs their
+ * requests itself.
  */
 function hasUsableAuth(auth: { apiKey?: unknown; headers?: unknown }): boolean {
 	if (typeof auth.apiKey === "string" && auth.apiKey.length > 0) return true;
-	if (auth.headers && typeof auth.headers === "object") {
-		return Object.values(auth.headers as Record<string, unknown>).some(
-			(value) => typeof value === "string" && value.length > 0,
-		);
-	}
-	return false;
+	return countUsableHeaders(auth.headers) > 0;
+}
+
+/** How many headers the auth payload carries at all (diagnostics only, never values). */
+function countHeaders(headers: unknown): number {
+	return headers && typeof headers === "object" ? Object.keys(headers as Record<string, unknown>).length : 0;
+}
+
+/** How many headers carry a non-empty string value — the ones pi could actually send. */
+function countUsableHeaders(headers: unknown): number {
+	if (!headers || typeof headers !== "object") return 0;
+	return Object.values(headers as Record<string, unknown>).filter(
+		(value) => typeof value === "string" && value.length > 0,
+	).length;
 }
 
 type NotifyLevel = "warning" | "info" | "error";
 type Notify = (message: string, type?: NotifyLevel) => void;
 export type ConsolidationPhase = "observer" | "reflector" | "dropper";
+
+/**
+ * Whether pi positively reports a working credential source for this model's provider.
+ *
+ * `ModelRegistry.hasConfiguredAuth(model)` is true when pi's availability check
+ * (`ModelRuntime.checkAuth`) resolved *something* for the provider — an API key, a
+ * stored credential, or an ambient source such as `AWS_PROFILE` / `AWS_ACCESS_KEY_ID`
+ * / gcloud ADC. Combined with `auth.ok === true` and an auth payload that carries
+ * nothing, that is the signature of a provider pi signs at request time:
+ *
+ *   pi has a credential source, and deliberately hands the caller nothing to attach.
+ *
+ * Measured on a Bedrock/SSO host (pi 0.84.2), with `AWS_PROFILE` exported:
+ *   checkAuth("amazon-bedrock") -> { source: "AWS_PROFILE", type: "api_key" }
+ *   hasConfiguredAuth(model)    -> true
+ *   getApiKeyAndHeaders(model)  -> { ok: true, apiKey: undefined, headers: undefined }
+ * `googleVertexProvider`'s ADC branch returns the same empty-auth resolution.
+ *
+ * The inverse case — `hasConfiguredAuth === false` with an empty auth payload — is a
+ * provider pi could not authenticate at all (no key, no ambient source). That must
+ * keep failing: it is the ordinary "not logged in" state, not ambient auth.
+ *
+ * Defensive: older pi versions and partial test doubles may not expose this, and an
+ * unknown answer must not be read as "authenticated".
+ */
+function hasConfiguredProviderCredential(registry: unknown, model: unknown): boolean {
+	try {
+		return (registry as { hasConfiguredAuth?: (m: unknown) => unknown }).hasConfiguredAuth?.(model) === true;
+	} catch {
+		return false;
+	}
+}
 
 export interface ResolveCtx {
 	model: unknown;
@@ -78,12 +124,56 @@ export class Runtime {
 		if (!model) return { ok: false, reason: "no model available (session has no model and no observational-memory model configured)" };
 		const auth = await ctx.modelRegistry.getApiKeyAndHeaders(model);
 		const provider = (model as { provider?: string }).provider ?? "unknown";
-		if (!auth.ok || !hasUsableAuth(auth)) {
-			const isOAuth = ctx.modelRegistry.isUsingOAuth?.(model) === true;
+		const isOAuth = ctx.modelRegistry.isUsingOAuth?.(model) === true;
+		// `auth.ok === false` is the only unambiguous failure: pi returns it when a
+		// provider requires a request auth header and no credential resolved.
+		//
+		// `auth.ok === true` with neither apiKey nor headers, for a provider pi DOES
+		// report a credential source for, is not a failure — it is how pi describes a
+		// provider that authenticates at request time: Amazon Bedrock signing SigV4 from
+		// ambient AWS credentials (`bedrockAuth.resolve` returns `{ auth: {}, source:
+		// "AWS_PROFILE" }`), Google Vertex using ADC (same empty resolution). pi's own
+		// native streaming path forwards no apiKey either, and its pre-prompt gate is
+		// merely `hasConfiguredAuth(provider) || checkAuth(provider) !== undefined` —
+		// om's pre-flight check must not be stricter than pi's own. Treating it as "no
+		// auth" aborted consolidation before the model was ever called, disabling
+		// observational memory silently — no error, no cost, no latency — on such hosts.
+		//
+		// Three cases deliberately keep failing: OAuth providers, where an empty
+		// resolution means the credentials no longer resolve and the user must log in
+		// again; a credential that resolved to an empty *string* key, which is a
+		// misconfiguration rather than ambient auth; and a provider pi reports no
+		// credential source for at all, which is simply unauthenticated.
+		const usable = hasUsableAuth(auth);
+		const resolvedEmptyApiKey = typeof auth.apiKey === "string" && auth.apiKey.length === 0;
+		const providerCredentialConfigured = hasConfiguredProviderCredential(ctx.modelRegistry, model);
+		const signsAtRequestTime =
+			auth.ok === true && !isOAuth && !resolvedEmptyApiKey && providerCredentialConfigured;
+		if (!auth.ok || (!usable && !signsAtRequestTime)) {
 			const reason = isOAuth
 				? `authentication failed for provider "${provider}" — OAuth credentials may have expired; run '/login ${provider}' to re-authenticate`
 				: `no API key or auth headers for provider "${provider}"`;
+			// The reason string alone cannot tell `ok: false` from `ok: true` with nothing to
+			// carry, which is what made the ambient-credential outage un-diagnosable from the
+			// debug log. Record the decision inputs — booleans and counts only, never values.
+			debugLog("resolve.rejected", {
+				provider,
+				reason,
+				authOk: auth.ok === true,
+				hasApiKey: typeof auth.apiKey === "string" && auth.apiKey.length > 0,
+				resolvedEmptyApiKey,
+				headerCount: countHeaders(auth.headers),
+				usableHeaderCount: countUsableHeaders(auth.headers),
+				isOAuth,
+				providerCredentialConfigured,
+				signsAtRequestTime,
+			});
 			return { ok: false, reason };
+		}
+		if (!usable) {
+			// Accepted with nothing to attach: pi signs this request itself. Logged so the
+			// ambient path is visible in the debug log instead of being inferred.
+			debugLog("resolve.request_time_signing", { provider, providerCredentialConfigured });
 		}
 		return { ok: true, model, apiKey: auth.apiKey as string | undefined, headers: auth.headers as Record<string, string> | undefined };
 	}

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -35,6 +35,19 @@ function countUsableHeaders(headers: unknown): number {
 	).length;
 }
 
+/**
+ * How long to wait for the availability re-check in `recheckProviderCredential`, and how
+ * long before the same provider may be re-checked again.
+ *
+ * The re-check is network-free and measured at ~1ms on a warm Bedrock/SSO host, but
+ * `checkAuth` can block on a provider's own credential resolution, so it is bounded. The
+ * re-arm interval keeps an unauthenticated host from paying the cost on every
+ * consolidation while still recovering within a session when credentials are renewed out
+ * of band (`aws sso login` in another terminal, `gcloud auth application-default login`).
+ */
+const AVAILABILITY_RECHECK_TIMEOUT_MS = 5_000;
+const AVAILABILITY_RECHECK_REARM_MS = 60_000;
+
 type NotifyLevel = "warning" | "info" | "error";
 type Notify = (message: string, type?: NotifyLevel) => void;
 export type ConsolidationPhase = "observer" | "reflector" | "dropper";
@@ -95,6 +108,8 @@ export class Runtime {
 	lastObserverError: string | undefined;
 	lastReflectorError: string | undefined;
 	lastDropperError: string | undefined;
+	/** provider -> epoch ms of the last availability re-check (see `recheckProviderCredential`). */
+	availabilityRecheckedAt = new Map<string, number>();
 	/** Deliberate-empty backoff (#23): skip observer re-fires over the same span until enough new tokens arrive. */
 	observerEmptyBackoff: {
 		sessionIdentity: string | undefined;
@@ -146,7 +161,28 @@ export class Runtime {
 		// credential source for at all, which is simply unauthenticated.
 		const usable = hasUsableAuth(auth);
 		const resolvedEmptyApiKey = typeof auth.apiKey === "string" && auth.apiKey.length === 0;
-		const providerCredentialConfigured = hasConfiguredProviderCredential(ctx.modelRegistry, model);
+		let providerCredentialConfigured = hasConfiguredProviderCredential(ctx.modelRegistry, model);
+		// pi's gate has TWO halves and never trusts the snapshot alone (agent-session.js):
+		//
+		//   hasConfiguredAuth(provider) || (await checkAuth(provider)) !== undefined
+		//
+		// `hasConfiguredAuth` reads `snapshot.configuredProviders`, which is populated by an
+		// availability pass — and left untouched when that pass is skipped
+		// (`refreshOnCreate: false`), aborted, or FAILS (its catch records `availabilityError`
+		// and returns). A provider whose credential could not be checked at startup — an
+		// expired SSO token, say — is therefore absent from the snapshot for the rest of the
+		// session, even after the user renews it out of band. pi recovers on the next turn
+		// because its second half re-checks live; reading only the snapshot half would leave
+		// consolidation dead for the whole session, which is the same silent-failure class as
+		// the bug this gate was fixed for.
+		//
+		// The facade exposes no `checkAuth`, but `refresh({ providers })` performs the same
+		// live check and then updates the snapshot, so re-reading afterwards is equivalent.
+		// Only attempted when everything else already looks like the ambient shape, so an
+		// ordinary unauthenticated provider still fails on the first call.
+		if (auth.ok === true && !usable && !isOAuth && !resolvedEmptyApiKey && !providerCredentialConfigured) {
+			providerCredentialConfigured = await this.recheckProviderCredential(ctx.modelRegistry, model, provider);
+		}
 		const signsAtRequestTime =
 			auth.ok === true && !isOAuth && !resolvedEmptyApiKey && providerCredentialConfigured;
 		if (!auth.ok || (!usable && !signsAtRequestTime)) {
@@ -176,6 +212,67 @@ export class Runtime {
 			debugLog("resolve.request_time_signing", { provider, providerCredentialConfigured });
 		}
 		return { ok: true, model, apiKey: auth.apiKey as string | undefined, headers: auth.headers as Record<string, string> | undefined };
+	}
+
+	/**
+	 * Re-check one provider's credential live, then re-read pi's snapshot.
+	 *
+	 * Implements the second half of pi's own auth gate for the only case that needs it: an
+	 * otherwise-ambient-looking resolution whose provider is missing from a stale or never
+	 * populated availability snapshot. Bounded and rate-limited; never throws.
+	 */
+	private async recheckProviderCredential(registry: unknown, model: unknown, provider: string): Promise<boolean> {
+		const last = this.availabilityRecheckedAt.get(provider);
+		const now = Date.now();
+		if (last !== undefined && now - last < AVAILABILITY_RECHECK_REARM_MS) return false;
+		this.availabilityRecheckedAt.set(provider, now);
+
+		const refresh = (registry as { refresh?: (options?: unknown) => Promise<unknown> }).refresh;
+		if (typeof refresh !== "function") {
+			debugLog("resolve.availability_recheck", { provider, refreshed: false, reason: "registry exposes no refresh()" });
+			return false;
+		}
+
+		const controller = new AbortController();
+		const timer = setTimeout(() => controller.abort(), AVAILABILITY_RECHECK_TIMEOUT_MS);
+		let refreshError: string | undefined;
+		let timedOut = false;
+		try {
+			// allowNetwork:false — a credential re-check must not wait on a model-catalog fetch.
+			// providers:[provider] — scope the work, and the snapshot writes, to the one provider.
+			//
+			// Both are honoured from pi 0.84; on pi 0.81 the facade is `refresh()` with no
+			// parameters, delegating to `runtime.reloadConfig()`, which reloads models.json and
+			// then runs a FULL, network-permitted availability pass. Passing the options is
+			// harmless there, but the work is wider and slower — hence the race below rather
+			// than relying on the abort signal, which that version never sees.
+			await Promise.race([
+				refresh.call(registry, { allowNetwork: false, providers: [provider], signal: controller.signal }),
+				new Promise<void>((resolve) => {
+					controller.signal.addEventListener("abort", () => {
+						timedOut = true;
+						resolve();
+					});
+				}),
+			]);
+		} catch (error) {
+			refreshError = error instanceof Error ? error.message : String(error);
+		} finally {
+			clearTimeout(timer);
+		}
+
+		// Re-read even when the refresh reported an error or timed out: a scoped pass can
+		// update the snapshot for this provider and still fail elsewhere.
+		const recovered = hasConfiguredProviderCredential(registry, model);
+		debugLog("resolve.availability_recheck", {
+			provider,
+			refreshed: refreshError === undefined && !timedOut,
+			recovered,
+			elapsedMs: Date.now() - now,
+			timedOut,
+			...(refreshError === undefined ? {} : { refreshError }),
+		});
+		return recovered;
 	}
 
 	launchConsolidationTask(ctx: LaunchCtx, work: () => Promise<void>): Promise<void> {

--- a/tests/ambient-credential-auth.test.ts
+++ b/tests/ambient-credential-auth.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from "vitest";
+
+import { ModelRegistry } from "@earendil-works/pi-coding-agent";
+
+import { Runtime } from "../src/runtime.js";
+
+/**
+ * Regression coverage for providers that authenticate at request time.
+ *
+ * Amazon Bedrock with ambient AWS credentials (AWS_PROFILE / SSO) and Google
+ * Vertex with ADC expose no apiKey and no auth header: pi signs each request
+ * itself. Before this fix, resolveModel treated "nothing to carry" as "not
+ * authenticated" and skipped every consolidation, so observational memory
+ * produced no records at all on such hosts — silently, since the model was
+ * never called and nothing failed.
+ *
+ * THE SHAPES BELOW ARE MEASURED, NOT IMAGINED. An earlier version of this file
+ * modelled the ambient host as `getAuth -> undefined, hasConfiguredAuth ->
+ * false`; the fix passed its tests and still skipped every consolidation on a
+ * real Bedrock/SSO host. Probing pi 0.84.2's own ModelRuntime there, with
+ * `AWS_PROFILE` exported, gives:
+ *
+ *   checkAuth("amazon-bedrock")            -> { source: "AWS_PROFILE", type: "api_key" }
+ *   hasConfiguredAuth(bedrockModel)        -> true
+ *   getCompatibilityRequestConfig(model)   -> { authHeader: false }
+ *   getApiKeyAndHeaders(bedrockModel)      -> { ok: true, apiKey: undefined, headers: undefined }
+ *
+ * i.e. pi resolves a credential *source* and hands back an *empty* auth —
+ * `bedrockAuth.resolve()` returns `{ auth: {}, source: "AWS_PROFILE" }`, so
+ * `hasConfiguredAuth` is TRUE, not false. `googleVertexProvider`'s ADC branch
+ * returns the same empty resolution. Doubles here therefore drive the REAL
+ * `ModelRegistry` over a runtime that returns those measured values, so the
+ * facade's own logic (not a hand-written imitation of it) is under test.
+ */
+
+/** Runtime shaped like Bedrock with AWS_PROFILE: a resolved source, empty auth. */
+function ambientCredentialRegistry(): any {
+	return new ModelRegistry({
+		// `bedrockAuth.resolve()` / vertex ADC: a resolution with nothing to carry.
+		getAuth: async () => ({ auth: {}, source: "AWS_PROFILE" }),
+		getCompatibilityRequestConfig: () => ({ headers: undefined, authHeader: false }),
+		// checkAuth resolved a source, so pi counts the provider as configured.
+		hasConfiguredAuth: () => true,
+		isUsingOAuth: () => false,
+	} as any);
+}
+
+/** No credential at all: pi resolves nothing and reports the provider unconfigured. */
+function unauthenticatedRegistry(): any {
+	return new ModelRegistry({
+		getAuth: async () => undefined,
+		getCompatibilityRequestConfig: () => ({ headers: undefined, authHeader: false }),
+		hasConfiguredAuth: () => false,
+		isUsingOAuth: () => false,
+	} as any);
+}
+
+/** Same empty-resolution shape, but the provider is OAuth — empty means expired. */
+function expiredOAuthRegistry(): any {
+	return new ModelRegistry({
+		getAuth: async () => ({ auth: {}, source: "stored credential" }),
+		getCompatibilityRequestConfig: () => ({ headers: undefined, authHeader: false }),
+		hasConfiguredAuth: () => true,
+		isUsingOAuth: () => true,
+	} as any);
+}
+
+/** A provider pi DOES hold a credential for, which resolves to an empty key. */
+function misconfiguredRegistry(): any {
+	return {
+		find: () => undefined,
+		getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "" }),
+		hasConfiguredAuth: () => true,
+		isUsingOAuth: () => false,
+	};
+}
+
+const bedrockModel = { provider: "amazon-bedrock", id: "eu.anthropic.claude-haiku-4-5-20251001-v1:0" };
+
+describe("resolveModel with request-time-signed providers", () => {
+	it("resolves when pi reports a credential source but hands over nothing to attach", async () => {
+		const runtime = new Runtime();
+		runtime.configLoaded = true;
+
+		const registry = ambientCredentialRegistry();
+		// Guard the premise: if pi's facade ever stops reporting this shape, fail here
+		// rather than silently testing a fiction (the original bug in this file).
+		const auth = await registry.getApiKeyAndHeaders(bedrockModel);
+		expect(auth).toMatchObject({ ok: true });
+		expect(auth.apiKey).toBeUndefined();
+		expect(registry.hasConfiguredAuth(bedrockModel)).toBe(true);
+
+		const result = await runtime.resolveModel({
+			model: bedrockModel,
+			modelRegistry: registry,
+			hasUI: false,
+		});
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.model).toBe(bedrockModel);
+			// Nothing to forward: pi signs the request itself.
+			expect(result.apiKey).toBeUndefined();
+			expect(result.headers).toBeUndefined();
+		}
+	});
+
+	it("still fails when pi reports no credential source for the provider", async () => {
+		const runtime = new Runtime();
+		runtime.configLoaded = true;
+
+		const result = await runtime.resolveModel({
+			model: bedrockModel,
+			modelRegistry: unauthenticatedRegistry(),
+			hasUI: false,
+		});
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.reason).toContain('no API key or auth headers for provider "amazon-bedrock"');
+	});
+
+	it("still fails for OAuth providers whose credentials no longer resolve", async () => {
+		const runtime = new Runtime();
+		runtime.configLoaded = true;
+
+		const result = await runtime.resolveModel({
+			model: { provider: "openai-codex", id: "gpt-5-codex" },
+			modelRegistry: expiredOAuthRegistry(),
+			hasUI: false,
+		});
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.reason).toContain("/login openai-codex");
+	});
+
+	it("still fails when a stored credential exists but resolves to an empty key", async () => {
+		const runtime = new Runtime();
+		runtime.configLoaded = true;
+
+		const result = await runtime.resolveModel({
+			model: { provider: "xai", id: "grok-4" },
+			modelRegistry: misconfiguredRegistry(),
+			hasUI: false,
+		});
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.reason).toContain('no API key or auth headers for provider "xai"');
+	});
+
+	it("does not accept an unconfigured provider just because auth.ok is true", async () => {
+		// The blunt version of this fix (accept any ok:true with nothing to carry) let
+		// every unauthenticated provider through. `hasConfiguredAuth` is what separates
+		// "pi signs this itself" from "pi has nothing at all".
+		const runtime = new Runtime();
+		runtime.configLoaded = true;
+
+		for (const hasConfiguredAuth of [false, undefined]) {
+			const result = await runtime.resolveModel({
+				model: { provider: "anthropic", id: "claude" },
+				modelRegistry: {
+					find: () => undefined,
+					getApiKeyAndHeaders: async () => ({ ok: true }),
+					hasConfiguredAuth: hasConfiguredAuth === undefined ? undefined : () => hasConfiguredAuth,
+					isUsingOAuth: () => false,
+				},
+				hasUI: false,
+			});
+			expect(result.ok).toBe(false);
+		}
+	});
+});

--- a/tests/ambient-credential-auth.test.ts
+++ b/tests/ambient-credential-auth.test.ts
@@ -169,3 +169,169 @@ describe("resolveModel with request-time-signed providers", () => {
 		}
 	});
 });
+
+/**
+ * Second half of pi's gate: a stale availability snapshot must not be fatal.
+ *
+ * pi never trusts the snapshot alone (agent-session.js:850-851):
+ *
+ *   hasConfiguredAuth(provider) || (await checkAuth(provider)) !== undefined
+ *
+ * `hasConfiguredAuth` reads `snapshot.configuredProviders`, which an availability pass
+ * fills. MEASURED against pi 0.84.2's real ModelRuntime on a live Bedrock/SSO host, using
+ * `ModelRuntime.create({ refreshOnCreate: false })` so the pass never populated it:
+ *
+ *   getApiKeyAndHeaders(model)   -> { ok: true, apiKey: undefined, headers: undefined }
+ *   hasConfiguredAuth(model)     -> FALSE        <- differs from the refreshed case
+ *   checkAuth("amazon-bedrock")  -> resolves     <- the credential genuinely works
+ *   refresh({ allowNetwork: false, providers: ["amazon-bedrock"] })  -> 1ms, then
+ *   hasConfiguredAuth(model)     -> true
+ *
+ * So the snapshot half alone rejects a provider pi itself would accept. This is reachable
+ * whenever the pass is skipped, aborted, or FAILS — e.g. an SSO token expired at startup
+ * and since renewed: pi recovers on its next turn, consolidation would stay dead for the
+ * whole session.
+ *
+ * VERSION SKEW, deliberately covered by two different doubles below. The facade's refresh
+ * differs across the pi versions this extension supports:
+ *   pi 0.84: `refresh(options)` -> `runtime.refresh(options)`      — honours the options
+ *   pi 0.81: `refresh()`        -> `runtime.reloadConfig()`        — ignores them, then
+ *            reloads models.json and runs a full, network-permitted availability pass
+ * The recovery must therefore work through either path, and must not depend on the abort
+ * signal being observed (0.81 never sees it), which is why the implementation races a
+ * timeout instead.
+ */
+describe("resolveModel with a stale availability snapshot", () => {
+	/**
+	 * The REAL facade over a runtime double, exposing both underlying entry points so the
+	 * test passes against either pi version's ModelRegistry.
+	 */
+	function staleSnapshotFacade(opts: { recovers: boolean }) {
+		const recoveries: string[] = [];
+		let configured = false;
+		const recover = (via: string) => {
+			recoveries.push(via);
+			if (opts.recovers) configured = true;
+			return { aborted: false, errors: new Map() };
+		};
+		const registry: any = new ModelRegistry({
+			getAuth: async () => ({ auth: {}, source: "AWS_PROFILE" }),
+			getCompatibilityRequestConfig: () => ({ headers: undefined, authHeader: false }),
+			hasConfiguredAuth: () => configured,
+			isUsingOAuth: () => false,
+			refresh: async () => recover("refresh"), // pi >= 0.84
+			reloadConfig: async () => recover("reloadConfig"), // pi 0.81
+		} as any);
+		return { registry, recoveries };
+	}
+
+	it("re-checks live and accepts when the snapshot was merely stale", async () => {
+		const runtime = new Runtime();
+		runtime.configLoaded = true;
+		const { registry, recoveries } = staleSnapshotFacade({ recovers: true });
+
+		const result = await runtime.resolveModel({ model: bedrockModel, modelRegistry: registry, hasUI: false });
+
+		expect(result.ok).toBe(true);
+		expect(recoveries).toHaveLength(1);
+	});
+
+	it("asks for a scoped, network-free re-check", async () => {
+		// Asserted against a plain registry double, because only pi >= 0.84 forwards these
+		// options at all — on 0.81 the facade drops them before the runtime sees them.
+		const runtime = new Runtime();
+		runtime.configLoaded = true;
+		const calls: unknown[] = [];
+		let configured = false;
+		const result = await runtime.resolveModel({
+			model: bedrockModel,
+			modelRegistry: {
+				find: () => undefined,
+				getApiKeyAndHeaders: async () => ({ ok: true }),
+				hasConfiguredAuth: () => configured,
+				isUsingOAuth: () => false,
+				refresh: async (options: unknown) => {
+					calls.push(options);
+					configured = true;
+				},
+			},
+			hasUI: false,
+		});
+
+		expect(result.ok).toBe(true);
+		expect(calls).toHaveLength(1);
+		expect(calls[0]).toMatchObject({ allowNetwork: false, providers: ["amazon-bedrock"] });
+	});
+
+	it("still rejects when the live re-check confirms the provider is unconfigured", async () => {
+		const runtime = new Runtime();
+		runtime.configLoaded = true;
+		const { registry, recoveries } = staleSnapshotFacade({ recovers: false });
+
+		const result = await runtime.resolveModel({ model: bedrockModel, modelRegistry: registry, hasUI: false });
+
+		expect(result.ok).toBe(false);
+		expect(recoveries).toHaveLength(1);
+	});
+
+	it("rate-limits the re-check so an unauthenticated host pays it once, not per consolidation", async () => {
+		const runtime = new Runtime();
+		runtime.configLoaded = true;
+		const { registry, recoveries } = staleSnapshotFacade({ recovers: false });
+
+		for (let i = 0; i < 3; i++) {
+			await runtime.resolveModel({ model: bedrockModel, modelRegistry: registry, hasUI: false });
+		}
+
+		expect(recoveries).toHaveLength(1);
+	});
+
+	it("does not re-check when auth is already usable", async () => {
+		const runtime = new Runtime();
+		runtime.configLoaded = true;
+		const { registry, recoveries } = staleSnapshotFacade({ recovers: true });
+		registry.getApiKeyAndHeaders = async () => ({ ok: true, apiKey: "sk-live" });
+
+		const result = await runtime.resolveModel({ model: bedrockModel, modelRegistry: registry, hasUI: false });
+
+		expect(result.ok).toBe(true);
+		expect(recoveries).toHaveLength(0);
+	});
+
+	it("does not re-check OAuth providers — an empty resolution there means expired", async () => {
+		const runtime = new Runtime();
+		runtime.configLoaded = true;
+		const { registry, recoveries } = staleSnapshotFacade({ recovers: true });
+		registry.isUsingOAuth = () => true;
+
+		const result = await runtime.resolveModel({ model: bedrockModel, modelRegistry: registry, hasUI: false });
+
+		expect(result.ok).toBe(false);
+		expect(recoveries).toHaveLength(0);
+	});
+
+	it("survives a registry with no refresh(), and a refresh that throws", async () => {
+		const runtime = new Runtime();
+		runtime.configLoaded = true;
+
+		const noRefresh = {
+			find: () => undefined,
+			getApiKeyAndHeaders: async () => ({ ok: true }),
+			hasConfiguredAuth: () => false,
+			isUsingOAuth: () => false,
+		};
+		await expect(
+			runtime.resolveModel({ model: bedrockModel, modelRegistry: noRefresh, hasUI: false }),
+		).resolves.toMatchObject({ ok: false });
+
+		const throwing = {
+			...noRefresh,
+			refresh: async () => {
+				throw new Error("availability refresh failed");
+			},
+		};
+		await expect(
+			runtime.resolveModel({ model: bedrockModel, modelRegistry: throwing, hasUI: false }),
+		).resolves.toMatchObject({ ok: false });
+	});
+});

--- a/tests/resolve-diagnostics.test.ts
+++ b/tests/resolve-diagnostics.test.ts
@@ -1,0 +1,139 @@
+import { mkdirSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mock = vi.hoisted(() => ({ agentDir: "" }));
+
+vi.mock("@earendil-works/pi-coding-agent", () => ({
+	getAgentDir: () => mock.agentDir,
+}));
+
+import { DEBUG_LOG_RELATIVE_PATH, withDebugLogContext } from "../src/debug-log.js";
+import { Runtime } from "../src/runtime.js";
+
+/**
+ * The ambient-credential outage was invisible for eight weeks partly because the
+ * only breadcrumb was `observer.model_unavailable` with a reason string that reads
+ * identically for `auth.ok === false` and for `auth.ok === true` with nothing to
+ * carry. Diagnosing it needed an out-of-band probe of pi's ModelRegistry. These
+ * tests pin the decision inputs into the debug log — and pin that no credential
+ * material ever goes in with them.
+ */
+describe("resolveModel debug diagnostics", () => {
+	let root: string;
+
+	beforeEach(() => {
+		root = `${tmpdir()}/om-resolve-diag-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+		mkdirSync(join(root, "agent"), { recursive: true });
+		mock.agentDir = join(root, "agent");
+	});
+
+	afterEach(() => {
+		rmSync(root, { recursive: true, force: true });
+	});
+
+	function events(): any[] {
+		return readFileSync(join(root, "agent", DEBUG_LOG_RELATIVE_PATH), "utf-8")
+			.trim()
+			.split("\n")
+			.filter(Boolean)
+			.map((line) => JSON.parse(line));
+	}
+
+	async function resolve(registry: unknown, model: unknown) {
+		const runtime = new Runtime();
+		runtime.configLoaded = true;
+		return withDebugLogContext({ enabled: true }, () =>
+			runtime.resolveModel({ model, modelRegistry: registry as any, hasUI: false }),
+		);
+	}
+
+	it("records why a resolve was rejected, not just the reason string", async () => {
+		const result = await resolve(
+			{
+				find: () => undefined,
+				getApiKeyAndHeaders: async () => ({ ok: true, headers: { Authorization: "" } }),
+				hasConfiguredAuth: () => false,
+				isUsingOAuth: () => false,
+			},
+			{ provider: "anthropic", id: "claude" },
+		);
+
+		expect(result.ok).toBe(false);
+		const rejected = events().filter((entry) => entry.event === "resolve.rejected");
+		expect(rejected).toHaveLength(1);
+		expect(rejected[0].data).toMatchObject({
+			provider: "anthropic",
+			authOk: true,
+			hasApiKey: false,
+			resolvedEmptyApiKey: false,
+			headerCount: 1,
+			usableHeaderCount: 0,
+			isOAuth: false,
+			providerCredentialConfigured: false,
+			signsAtRequestTime: false,
+		});
+	});
+
+	it("distinguishes a stored-but-empty key from an unconfigured provider", async () => {
+		await resolve(
+			{
+				find: () => undefined,
+				getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "" }),
+				hasConfiguredAuth: () => true,
+				isUsingOAuth: () => false,
+			},
+			{ provider: "xai", id: "grok-4" },
+		);
+
+		const [rejected] = events().filter((entry) => entry.event === "resolve.rejected");
+		expect(rejected.data).toMatchObject({
+			provider: "xai",
+			resolvedEmptyApiKey: true,
+			providerCredentialConfigured: true,
+			signsAtRequestTime: false,
+		});
+	});
+
+	it("records the request-time-signing acceptance path", async () => {
+		const result = await resolve(
+			{
+				find: () => undefined,
+				getApiKeyAndHeaders: async () => ({ ok: true }),
+				hasConfiguredAuth: () => true,
+				isUsingOAuth: () => false,
+			},
+			{ provider: "amazon-bedrock", id: "eu.anthropic.claude-haiku-4-5-20251001-v1:0" },
+		);
+
+		expect(result.ok).toBe(true);
+		const accepted = events().filter((entry) => entry.event === "resolve.request_time_signing");
+		expect(accepted).toHaveLength(1);
+		expect(accepted[0].data).toMatchObject({ provider: "amazon-bedrock", providerCredentialConfigured: true });
+		expect(events().some((entry) => entry.event === "resolve.rejected")).toBe(false);
+	});
+
+	it("never writes credential material into the debug log", async () => {
+		await resolve(
+			{
+				find: () => undefined,
+				getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "sk-secret-key", headers: { Authorization: "Bearer secret-token" } }),
+				hasConfiguredAuth: () => true,
+				isUsingOAuth: () => false,
+			},
+			{ provider: "anthropic", id: "claude" },
+		);
+
+		// A successful resolve with usable auth logs nothing at all; assert the file
+		// either does not exist or contains no secret, without depending on which.
+		let contents = "";
+		try {
+			contents = readFileSync(join(root, "agent", DEBUG_LOG_RELATIVE_PATH), "utf-8");
+		} catch {
+			contents = "";
+		}
+		expect(contents).not.toContain("sk-secret-key");
+		expect(contents).not.toContain("secret-token");
+	});
+});


### PR DESCRIPTION
Fixes #51

Fixes silent, total failure of consolidation on providers that carry no API key and
no auth header because the host signs each request itself.

**This needs no change to pi.** It works on stock pi 0.84.2.

Two commits, and the second is not cosmetic:

1. `6f694e6` — accept a resolution that carries nothing when pi reports a credential
   *source* for the provider.
2. `699ccc7` — re-check that report live before giving up, because it is read from a
   snapshot that can legitimately be empty while the credential works.

## This used to work

Evidence from a second Bedrock host's logs, independent of the host the fix was developed
on: om wrote 30 records on **2026-06-23** under the *stricter* pre-#36 gate (`!auth.ok ||
!auth.apiKey`), and from **2026-06-25** that host's logs carry `no API key for provider`
1727 times, then the current `no API key or auth headers for provider` 238 times after it
updated. So pi stopped surfacing an apiKey for request-time-signed providers somewhere in
**2026-06-23..06-25**, and consolidation has been dead on such hosts ever since — across
two different reason strings.

## Symptom

On a host using Amazon Bedrock with ambient AWS credentials (`AWS_PROFILE` / SSO),
every consolidation aborts before the worker model is called:

```
observer.model_unavailable   no API key or auth headers for provider "amazon-bedrock"
```

There is no error, no cost, and no latency — `ctx.ui.notify` warnings never reach the
transcript, so the only symptom is that `om.observations.recorded` never appears. On the
host this was found on, that produced **zero records across 11 sessions over 8 weeks**
while the extension loaded, ran, and reported healthy.

`AWS_BEARER_TOKEN_BEDROCK` works around it (it materialises an apiKey). Ambient
`AWS_PROFILE` / SSO — the normal enterprise posture, and the one where `auth.json` stays
empty by design — does not.

## Root cause

`Runtime.resolveModel` treats "no apiKey and no header" as unauthenticated. For providers
that sign at request time, that is exactly what a *successful* resolution looks like.
Measured against pi 0.84.2's real `ModelRuntime`/`ModelRegistry` with `AWS_PROFILE`
exported:

```
checkAuth("amazon-bedrock")       -> { source: "AWS_PROFILE", type: "api_key" }
hasConfiguredAuth(bedrockModel)   -> true
getApiKeyAndHeaders(bedrockModel) -> { ok: true, apiKey: undefined, headers: undefined }
```

`bedrockAuth.resolve()` returns `{ auth: {}, source: "AWS_PROFILE" }` — a resolved
credential *source* with an *empty* payload. pi therefore counts the provider as
configured and hands the caller nothing to attach, because `pi-ai`'s Bedrock provider
resolves the profile and owns SigV4 itself (`api/bedrock-converse-stream.js`: `profile:
optionsProfile || getProviderEnvValue("AWS_PROFILE", options.env)`; apiKey is only
consumed as an optional bearer-token *alternative*). `googleVertexProvider`'s ADC branch
returns the same empty resolution.

So the ambient signature is: **pi has a credential source and deliberately gives you
nothing to send.**

## Why the current rule is right for #36 and wrong here

#36 introduced `hasUsableAuth()` with this docstring, and it is accurate:

> Mirrors pi's own request-auth acceptance rule (`AgentSession._getRequiredRequestAuth`):
> resolved auth is usable when it carries an apiKey OR at least one header value.

The subtlety is that **pi has two request-auth rules, chosen by call purpose**, and om's
consolidation belongs to the other one:

| pi method | Rule | Used for |
|---|---|---|
| `_getRequiredRequestAuth` | strict — requires `apiKey \|\| headers`, else throws | the user's own turns |
| `_getSummarizationRequestAuth` | lenient — `if (!result) return { model }`, `catch { return { model } }` | compaction, auto-compaction, branch summaries |

om's observer/reflector/dropper are auxiliary background calls — pi's second category. pi
is deliberately lenient there, and it had to be: pi 0.80.7 fixed *its own* branch
summaries for this exact class of provider —

> Fixed branch summaries to work with providers that use ambient authentication instead of
> API keys (#6595)

— so #36 mirrored the strict rule for a call that pi itself handles leniently. This PR
aligns om's pre-flight with the rule matching its call class. Framed as an invariant:

> **om's pre-flight must not be stricter than pi's own gate**, which for a provider it
> will happily prompt against is merely `hasConfiguredAuth(provider) || checkAuth(provider)
> !== undefined`.

## The fix (`6f694e6`)

Reject only when the resolution is genuinely unusable:

```ts
const usable = hasUsableAuth(auth);
const resolvedEmptyApiKey = typeof auth.apiKey === "string" && auth.apiKey.length === 0;
const providerCredentialConfigured = hasConfiguredProviderCredential(ctx.modelRegistry, model);
const signsAtRequestTime =
    auth.ok === true && !isOAuth && !resolvedEmptyApiKey && providerCredentialConfigured;
if (!auth.ok || (!usable && !signsAtRequestTime)) { /* reject as before */ }
```

Deliberately still failing:

1. **`auth.ok === false`** — pi's own unambiguous failure.
2. **OAuth providers with an empty resolution** — credentials expired; the user must
   `/login` again. Keeps #37's behaviour intact.
3. **An apiKey that resolved to the empty string** — misconfiguration, not ambient auth.
4. **A provider pi reports no credential source for** — ordinary "not logged in".

## The second half of pi's gate (`699ccc7`)

`hasConfiguredAuth` is not a live check. It reads
`ModelRuntime.snapshot.configuredProviders`, which an availability pass fills — and which
is left untouched when that pass is skipped (`refreshOnCreate: false`), aborted, or
**fails**: `queueAvailabilityRefresh`'s catch records `availabilityError` and returns
without writing the snapshot. A provider whose credential could not be checked at that
moment is therefore absent for the rest of the session, *even once it works again*.

pi does not have this problem, because its gate never trusts the snapshot alone
(`agent-session.js:850-851`):

```js
const hasConfiguredAuth = this._modelRuntime.hasConfiguredAuth(this.model.provider) ||
    (await this._modelRuntime.checkAuth(this.model.provider)) !== undefined;
```

The realistic case is an SSO token that had expired when pi started and has since been
renewed in another terminal: pi recovers on its next turn via that second half, while
consolidation would stay dead for the whole session. Same silent-failure class as the bug
above — rarer, and therefore harder to notice.

The facade exposes no `checkAuth`, but `refresh({ providers })` performs the same live
check and then updates the snapshot, so re-reading afterwards is equivalent. On the
otherwise-fatal path only, and only when the resolution already looks ambient, om now
re-checks once and re-reads. Guard rails:

- **Rate-limited** per provider (60s): an unauthenticated host pays one network-free check,
  not one per consolidation, while a credential renewed mid-session is still picked up.
- **Bounded by a raced timeout**, not the abort signal alone — see the version note below.
- **Never throws**: no `refresh`, a throwing `refresh`, and a timeout all fall back to the
  previous rejection.
- **`resolve.availability_recheck`** records `provider, refreshed, recovered, elapsedMs,
  timedOut, refreshError?`, so a recovery is visible rather than inferred and a re-check
  that did *not* help is diagnosable.

### Version note, since this extension supports both

| | facade | behaviour |
|---|---|---|
| pi >= 0.84 | `refresh(options)` -> `runtime.refresh(options)` | honours `allowNetwork` / `providers` / `signal` |
| pi 0.81 | `refresh()` -> `runtime.reloadConfig()` | ignores all of them, then reloads `models.json` and runs a **full, network-permitted** availability pass |

0.81 therefore never sees the abort signal, which is why the timeout is a race rather than
a cancellation. The options are passed regardless: harmless there, scoping the work from
0.84 on. Both facades are pinned by separate doubles in the tests.

> For anyone reproducing this: run the differential against the **host** pi, not the
> `^0.81.0` devDependency. Under 0.81 `ModelRuntime.create` ignores `refreshOnCreate`, so
> the snapshot is always populated and the failing state never materialises. My own first
> differential run was invalid for exactly that reason.

## Why not simply accept `auth.ok === true`?

Because `ok: true` does not mean "authenticated". When `getAuth` resolves nothing and the
provider's `authHeader` is false — which it is for *every* builtin, via
`authHeader: extension?.authHeader ?? config?.authHeader ?? false` — `getApiKeyAndHeaders`
returns `{ ok: true, headers: undefined }`. A completely unconfigured builtin provider is
therefore byte-identical to ambient Bedrock at that call. `hasConfiguredAuth` is the only
way to separate them, which is why the `providerCredentialConfigured` half is load-bearing
and has its own test (*"does not accept an unconfigured provider just because auth.ok is
true"*).

This is also why an earlier attempt at this fix **did not work**: it keyed acceptance on
`hasConfiguredAuth(model) === false`, which inverts the real signal — on a genuine ambient
host that value is `true`. It passed its own tests because the test double asserted a
shape no ambient host produces. The doubles in `tests/ambient-credential-auth.test.ts` now
carry the measured values and assert the premise before asserting behaviour.

## Diagnosability (shipped in the same commits)

The reason string alone can't distinguish `ok: false` from `ok: true`-with-nothing-to-carry,
which is what made this un-diagnosable from the debug log. Added:

- `resolve.rejected` — the decision inputs: `authOk`, `hasApiKey`, `resolvedEmptyApiKey`,
  `headerCount`, `usableHeaderCount`, `isOAuth`, `providerCredentialConfigured`,
  `signsAtRequestTime`. **Booleans and counts only — never credential values**, pinned by a
  test.
- `resolve.request_time_signing` — the accept path. A positive line, because otherwise
  success looks identical to the extension never running.
- `resolve.availability_recheck` — the live re-check and whether it recovered.

All three are pinned by a test asserting no credential material can reach the log.

## Verification

- `tsc --noEmit` clean; **256 tests / 27 files passing** (7 new for the re-check).
- **Live differential**, one process, both implementations against the real `ModelRuntime`
  and a Bedrock/SSO host's ambient credentials:

  | runtime state | upstream 3.0.4 | `6f694e6` | `699ccc7` |
  |---|---|---|---|
  | normal startup | `ok:false` | `ok:true` | `ok:true` |
  | availability pass never populated the provider | `ok:false` | `ok:false` | `ok:true` in 2ms |

  Both `ok:false` results reproduce reason strings the affected hosts' debug logs actually
  produced, so the differential is evidence rather than decoration. After the re-check,
  `hasConfiguredAuth` reads `true`.
- **End to end on that host**: `resolve.request_time_signing` -> `observer.start` ->
  `observer.records` -> `observer.appended` -> `om.observations.recorded` in the
  transcript, then `reflector.result {reason: "accepted_nonempty",
  acceptedReflectionCount: 2}` and `om.reflections.recorded`. `recall()` round-trips from a
  reflection id through its supporting observations to the raw source entries. That
  session's debug log contains **0** `resolve.rejected` / `model_unavailable`; the
  pre-patch session on the same host, same day, contains **68**.

## Relationship to #49

#49 (`fix: forward env for cloudflare-workers-ai model resolution`) touches the same ten
lines of `resolveModel` — the `ResolveResult` union and the success `return`. The changes
are **orthogonal and complementary**: #49 extends *what is forwarded once the gate passes*
(`env`, `baseUrl`); this PR fixes *when the gate passes*. Whichever lands first, the other
is a trivial rebase — happy to do it in either order.

They are also complementary for this provider specifically: a user whose Bedrock profile
is scoped in `auth.json` rather than the ambient environment needs #49's `env` forwarding,
because `pi-ai`'s Bedrock provider reads `options.env?.AWS_PROFILE`. This PR alone covers
the ambient-environment case; the two together cover both.

## Not measured

- **Google Vertex ADC** is reasoned from `googleVertexProvider`'s empty-resolution branch
  returning the same shape as Bedrock's, not measured on a live Vertex host. The fix is
  not Bedrock-specific, but only the Bedrock path has live evidence.
- The gate accepts based on pi *reporting* a credential source; if that source is stale,
  the failure now surfaces from the provider call itself (a real error) instead of a silent
  pre-flight skip. That is the intended trade: a loud failure beats a silent one.

## Follow-up, not in this PR

`ctx.modelRegistry` is typed `any` in `ResolveCtx` and probed with optional chaining
(`isUsingOAuth?.`, `hasConfiguredAuth?.`). pi's `ModelRegistry` is explicitly public — its
own docstring reads *"Synchronous compatibility facade exposed to extensions"* — so this
could import the real type and drop the duck-typing. Left out to keep the fix reviewable;
happy to do it here or in a follow-up.