### PR TITLE
feat: append customInstructions from session_before_compact to summary

### DIFF
--- a/src/hooks/compaction-hook.ts
+++ b/src/hooks/compaction-hook.ts
@@ -38,10 +38,13 @@ export function registerCompactionHook(pi: ExtensionAPI, runtime: Runtime): void
 				firstKeptEntryId,
 				{ observationsPoolMaxTokens: observationsPoolMaxTokens(runtime) },
 			);
-			const summary = renderSummary(projection.reflections, projection.observations);
+			let summary = renderSummary(projection.reflections, projection.observations);
 			if (summary.length === 0) {
 				// Decline ownership so Pi's native summarizer preserves the pre-cut context.
 				return;
+			}
+			if (event.customInstructions) {
+				summary = `${summary}\n\n---\n${event.customInstructions}`;
 			}
 
 			return {


### PR DESCRIPTION
## Summary
Append `event.customInstructions` (from `session_before_compact`) to the rendered compaction summary when present. Closes #55.

## Why
`session_before_compact` already carries `customInstructions` (forwarded by `ctx.compact({ customInstructions })`), but the hook ignored it. Other extensions/tools can use this field to inject focus notes or task-boundary context into the compacted memory. This enables cross-extension composition without touching package internals.

## Change
- `const summary` -> `let summary`
- After the existing "decline ownership if empty" check, append `customInstructions` separated by a `---` divider.

Behavior is unchanged when `customInstructions` is absent.

## Test plan
- [ ] Compaction with no `customInstructions` -> summary unchanged.
- [ ] Compaction with `customInstructions` set -> note appended after `---`.
